### PR TITLE
Local variable 'cfunmet' referenced before assignment

### DIFF
--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -4460,10 +4460,10 @@ class Arr:
                             .first()
                         )
                         if episode.EpisodeFileId != 0:
-                            cfunmet = customFormat < episode.CustomFormatScore                            
+                            cfunmet = customFormat < episode.CustomFormatScore
                             if self.force_minimum_custom_format:
                                 cfunmet = cfunmet & customFormat < episode.MinCustomFormatScore
-                                
+
                         if cfunmet:
                             return True
                         else:

--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -4460,9 +4460,10 @@ class Arr:
                             .first()
                         )
                         if episode.EpisodeFileId != 0:
-                            cfunmet = customFormat < episode.CustomFormatScore
-                        if self.force_minimum_custom_format:
-                            cfunmet = cfunmet & customFormat < episode.MinCustomFormatScore
+                            cfunmet = customFormat < episode.CustomFormatScore                            
+                            if self.force_minimum_custom_format:
+                                cfunmet = cfunmet & customFormat < episode.MinCustomFormatScore
+                                
                         if cfunmet:
                             return True
                         else:
@@ -4523,8 +4524,8 @@ class Arr:
                     )
                     if movie.MovieFileId != 0:
                         cfunmet = customFormat < movie.CustomFormatScore
-                    if self.force_minimum_custom_format:
-                        cfunmet = cfunmet & customFormat < movie.MinCustomFormatScore
+                        if self.force_minimum_custom_format:
+                            cfunmet = cfunmet & customFormat < movie.MinCustomFormatScore
                     if cfunmet:
                         return True
                     else:

--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -4435,6 +4435,9 @@ class Arr:
                     completed = True
             if len(queue["records"]) > 0:
                 if self.type == "sonarr":
+                    # assuming by default it's not unmet to prevent early reseraching and deleeting
+                    cfunmet = False
+
                     if not self.series_search:
                         entry = next(
                             (
@@ -4444,8 +4447,10 @@ class Arr:
                             ),
                             None,
                         )
+
                         if not entry:
                             return False
+
                         customFormat = next(
                             (
                                 record["customFormatScore"]
@@ -4454,20 +4459,19 @@ class Arr:
                             ),
                             None,
                         )
+
                         episode = (
                             self.model_file.select()
                             .where(self.model_file.EntryId == entry)
                             .first()
                         )
+
                         if episode.EpisodeFileId != 0:
                             cfunmet = customFormat < episode.CustomFormatScore
                             if self.force_minimum_custom_format:
                                 cfunmet = cfunmet & customFormat < episode.MinCustomFormatScore
 
-                        if cfunmet:
-                            return True
-                        else:
-                            return False
+                        return cfunmet
                     else:
                         entry = next(
                             (
@@ -4477,8 +4481,10 @@ class Arr:
                             ),
                             None,
                         )
+
                         if not entry:
                             return False
+
                         customFormat = next(
                             (
                                 record["customFormatScore"]
@@ -4487,19 +4493,17 @@ class Arr:
                             ),
                             None,
                         )
+
                         series = (
                             self.model_file.select()
                             .where(self.model_file.EntryId == entry)
                             .first()
                         )
+
                         if self.force_minimum_custom_format:
                             cfunmet = customFormat < series.MinCustomFormatScore
-                        else:
-                            return True
-                        if cfunmet:
-                            return True
-                        else:
-                            return False
+
+                        return cfunmet
                 elif self.type == "radarr":
                     entry = next(
                         (
@@ -4509,8 +4513,10 @@ class Arr:
                         ),
                         None,
                     )
+
                     if not entry:
                         return False
+
                     customFormat = next(
                         (
                             record["customFormatScore"]
@@ -4522,14 +4528,16 @@ class Arr:
                     movie = (
                         self.model_file.select().where(self.model_file.EntryId == entry).first()
                     )
+
+                    # assuming by default it's not unmet to prevent early reseraching and deleeting
+                    cfunmet = False
+
                     if movie.MovieFileId != 0:
                         cfunmet = customFormat < movie.CustomFormatScore
                         if self.force_minimum_custom_format:
                             cfunmet = cfunmet & customFormat < movie.MinCustomFormatScore
-                    if cfunmet:
-                        return True
-                    else:
-                        return False
+
+                    return cfunmet
         except KeyError:
             pass
 


### PR DESCRIPTION
Fixed 

This should make the code easier to understand while maintaining the original logic

> local variable 'cfunmet' referenced before assignment
> Traceback (most recent call last):
>   File "/usr/local/lib/python3.10/site-packages/qBitrr/arss.py", line 3283, in process_torrents
>     self._process_single_torrent(torrent)
>   File "/usr/local/lib/python3.10/site-packages/qBitrr/arss.py", line 4291, in _process_single_torrent
>     and self.custom_format_unmet_check(torrent)
>   File "/usr/local/lib/python3.10/site-packages/qBitrr/arss.py", line 4527, in custom_format_unmet_check
>     cfunmet = cfunmet & customFormat < movie.MinCustomFormatScore