### PR TITLE
use "SeriesSearch" in post_command. self.search_api_command was null …

### DIFF
--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -3004,7 +3004,7 @@ class Arr:
                 while True:
                     try:
                         self.client.post_command(
-                            self.search_api_command, seriesId=file_model.EntryId
+                            "SeriesSearch", seriesId=file_model.EntryId
                         )
                         break
                     except (

--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -3003,9 +3003,7 @@ class Arr:
                 ).on_conflict_replace().execute()
                 while True:
                     try:
-                        self.client.post_command(
-                            "SeriesSearch", seriesId=file_model.EntryId
-                        )
+                        self.client.post_command("SeriesSearch", seriesId=file_model.EntryId)
                         break
                     except (
                         requests.exceptions.ChunkedEncodingError,

--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -1003,7 +1003,7 @@ class Arr:
                     self.logger.trace("Research series id: %s", series_id)
                     while True:
                         try:
-                            self.client.post_command(self.search_api_command, seriesId=series_id)
+                            self.client.post_command("SeriesSearch", seriesId=series_id)
                             break
                         except (
                             requests.exceptions.ChunkedEncodingError,

--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -3003,7 +3003,9 @@ class Arr:
                 ).on_conflict_replace().execute()
                 while True:
                     try:
-                        self.client.post_command(self.search_api_command, seriesId=file_model.EntryId)
+                        self.client.post_command(
+                            self.search_api_command, seriesId=file_model.EntryId
+                        )
                         break
                     except (
                         requests.exceptions.ChunkedEncodingError,

--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -476,11 +476,11 @@ class Arr:
                     "Script Config:  SearchRequestsEvery=%s", self.search_requests_every_x_seconds
                 )
 
-            if self.type == "sonarr":
-                if self.quality_unmet_search or self.do_upgrade_search:
-                    self.search_api_command = "SeriesSearch"
-                else:
-                    self.search_api_command = "MissingEpisodeSearch"
+        if self.type == "sonarr":
+            if self.quality_unmet_search or self.do_upgrade_search or self.series_search:
+                self.search_api_command = "SeriesSearch"
+            else:
+                self.search_api_command = "MissingEpisodeSearch"
 
         if not QBIT_DISABLED and not TAGLESS:
             self.manager.qbit_manager.client.torrents_create_tags(
@@ -1003,7 +1003,7 @@ class Arr:
                     self.logger.trace("Research series id: %s", series_id)
                     while True:
                         try:
-                            self.client.post_command("SeriesSearch", seriesId=series_id)
+                            self.client.post_command(self.search_api_command, seriesId=series_id)
                             break
                         except (
                             requests.exceptions.ChunkedEncodingError,
@@ -3003,7 +3003,7 @@ class Arr:
                 ).on_conflict_replace().execute()
                 while True:
                     try:
-                        self.client.post_command("SeriesSearch", seriesId=file_model.EntryId)
+                        self.client.post_command(self.search_api_command, seriesId=file_model.EntryId)
                         break
                     except (
                         requests.exceptions.ChunkedEncodingError,


### PR DESCRIPTION
uses "SeriesSearch" in post_command instead of self.search_api_command which is set to null unless self.search_missing is true which is not the case for everyone. 