### PR TITLE
docs: Add Requestrr integration documentation

### DIFF
--- a/docs/configuration/search/index.md
+++ b/docs/configuration/search/index.md
@@ -48,35 +48,17 @@ SearchPeriodDays = 30  # Monthly (conservative)
 
 ## Request Integration
 
-### Overseerr
+### Supported Request Systems
 
-Integrate qBitrr with Overseerr for request-driven automation:
+| System | Type | qBitrr Support |
+|--------|------|----------------|
+| [Overseerr](overseerr.md) | Full request management | ✅ Native API polling |
+| [Ombi](ombi.md) | Full request management | ✅ Native API polling |
+| [Requestrr](requestrr.md) | Discord chatbot | ✅ Via Overseerr or Ombi |
 
-```toml
-[Settings.Overseerr]
-Enabled = true
-URI = "http://localhost:5055"
-APIKey = "your-overseerr-api-key"
-CheckInterval = 300  # Check every 5 minutes
-```
-
-**Features:**
-- Monitor new requests
-- Trigger immediate searches
-- Priority handling for user requests
-- Status updates back to Overseerr
-
-### Ombi
-
-Configure Ombi integration similarly:
-
-```toml
-[Settings.Ombi]
-Enabled = true
-URI = "http://localhost:3579"
-APIKey = "your-ombi-api-key"
-CheckInterval = 300
-```
+!!! tip "Requestrr Users"
+    Requestrr is a Discord chatbot. Connect it to **Overseerr or Ombi**, then qBitrr
+    will process requests through its existing integration.
 
 ### Request Priority
 

--- a/docs/configuration/search/ombi.md
+++ b/docs/configuration/search/ombi.md
@@ -1,5 +1,10 @@
 # Ombi Integration
 
+!!! tip "Requestrr Integration"
+    Want Discord-based requests? Configure Requestrr to use Ombi as its backend,
+    then qBitrr will automatically process those requests.
+    [**→ Requestrr Integration Guide**](requestrr.md)
+
 Ombi is a self-hosted request management system for Plex, Emby, and Jellyfin. qBitrr can integrate with Ombi to automatically search for user-requested content, ensuring requests are fulfilled quickly and efficiently.
 
 ## Overview

--- a/docs/configuration/search/overseerr.md
+++ b/docs/configuration/search/overseerr.md
@@ -1,5 +1,10 @@
 # Overseerr Integration
 
+!!! tip "Requestrr Integration"
+    Want Discord-based requests? Configure Requestrr to use Overseerr as its backend,
+    then qBitrr will automatically process those requests.
+    [**→ Requestrr Integration Guide**](requestrr.md)
+
 Overseerr is a request management and media discovery tool. qBitrr can integrate with Overseerr to automatically search for user-requested content, ensuring your users get their requests fulfilled as quickly as possible.
 
 ## Overview

--- a/docs/configuration/search/requestrr.md
+++ b/docs/configuration/search/requestrr.md
@@ -1,0 +1,174 @@
+# Requestrr Integration
+
+Requestrr is a Discord chatbot that allows users to request movies, TV shows, and music through Discord. qBitrr integrates with Requestrr **through Overseerr or Ombi** as the request management backend.
+
+## How It Works
+
+Requestrr is a chatbot interface - it doesn't have its own request database. Instead:
+- Requestrr forwards user requests to Overseerr or Ombi
+- Overseerr/Ombi stores requests in their database
+- qBitrr polls Overseerr/Ombi API to find and search for requests
+
+```
+┌──────────┐     ┌───────────┐     ┌──────────────────┐     ┌──────────┐
+│  User    │────▶│ Requestrr │────▶│ Overseerr OR Ombi│────▶│  qBitrr  │
+│(Discord) │     │(Chatbot)  │     │   (Request DB)   │     │ (Search) │
+└──────────┘     └───────────┘     └──────────────────┘     └──────────┘
+```
+
+## Supported Backends
+
+| Backend | Support Level | Notes |
+|---------|--------------|-------|
+| **Overseerr** | ✅ Full | Recommended - 4K support, release date filtering |
+| **Ombi** | ✅ Full | Alternative - simpler setup |
+
+## Setup Instructions
+
+### Step 1: Configure Requestrr
+
+Configure Requestrr to use **either** Overseerr or Ombi:
+
+**Option A: Connect to Overseerr**
+1. Open Requestrr settings
+2. Navigate to **Overseerr** configuration
+3. Enter Overseerr URI, API key, and user mapping
+4. Save settings
+
+**Option B: Connect to Ombi**
+1. Open Requestrr settings
+2. Navigate to **Ombi** configuration
+3. Enter Ombi URI, API key, and user mapping
+4. Save settings
+
+For detailed Requestrr configuration, see the [Requestrr Wiki](https://github.com/thomst08/requestrr/wiki).
+
+### Step 2: Configure Overseerr or Ombi
+
+**If using Overseerr:**
+- Connect Overseerr to your Radarr/Sonarr/Lidarr instances
+- Configure quality profiles, root folders, and user permissions
+- Requests will automatically appear in Overseerr
+
+**If using Ombi:**
+- Connect Ombi to your Radarr/Sonarr instances
+- Configure quality profiles and root folders
+- Requests will automatically appear in Ombi
+
+### Step 3: Configure qBitrr
+
+Configure qBitrr to poll the **same** Overseerr/Ombi instance:
+
+**Option A: Overseerr Backend**
+```toml
+[Radarr-Movies.EntrySearch]
+SearchMissing = true
+
+[Radarr-Movies.EntrySearch.Overseerr]
+SearchOverseerrRequests = true
+OverseerrURI = "http://localhost:5055"
+OverseerrAPIKey = "your-api-key"
+ApprovedOnly = true
+```
+
+**Option B: Ombi Backend**
+```toml
+[Radarr-Movies.EntrySearch]
+SearchMissing = true
+
+[Radarr-Movies.EntrySearch.Ombi]
+SearchOmbiRequests = true
+OmbiURI = "http://localhost:3579"
+OmbiAPIKey = "your-api-key"
+ApprovedOnly = true
+```
+
+## Complete Docker Compose Example
+
+```yaml
+version: '3.8'
+services:
+  requestrr:
+    image: thomst08/requestrr:latest
+    container_name: requestrr
+    environment:
+      - TZ=America/New_York
+      - REQUESTRR_PORT=4545
+    ports:
+      - "4545:4545"
+    volumes:
+      - /path/to/requestrr/config:/root/config
+    restart: unless-stopped
+
+  overseerr:
+    image: sctx/overseerr:latest
+    container_name: overseerr
+    environment:
+      - LOG_LEVEL=info
+      - TZ=America/New_York
+    ports:
+      - "5055:5055"
+    volumes:
+      - /path/to/overseerr/config:/app/config
+    restart: unless-stopped
+
+  qbitrr:
+    image: feramance/qbitrr:latest
+    container_name: qbitrr
+    environment:
+      - TZ=America/New_York
+      # Overseerr integration
+      - QBITRR_RADARR_MOVIES__ENTRYSEARCH__OVERSEERR__SEARCHOVERSEERRQUESTS=true
+      - QBITRR_RADARR_MOVIES__ENTRYSEARCH__OVERSEERR__OVERSEERRURI=http://overseerr:5055
+      - QBITRR_RADARR_MOVIES__ENTRYSEARCH__OVERSEERR__OVERSEERRAPIKEY=overseerr-api-key
+    volumes:
+      - /path/to/qbitrr/config:/config
+    depends_on:
+      - overseerr
+    restart: unless-stopped
+```
+
+## Frequently Asked Questions
+
+### Does qBitrr know requests came from Requestrr?
+
+**No.** qBitrr sees all requests from Overseerr/Ombi identically, regardless of whether they came from:
+- The Overseerr/Ombi web interface
+- The Requestrr Discord chatbot
+- Any other integration
+
+This is by design - qBitrr prioritizes all requests equally based on approval status and release date.
+
+### Can Requestrr requests be prioritized differently?
+
+Not currently. All requests from Overseerr/Ombi are processed equally. If you need Requestrr-specific prioritization, consider:
+1. Filing a feature request with Requestrr for tag-based forwarding
+2. Using different quality profiles for Requestrr requests
+
+### What if I use both Requestrr and direct Overseerr/Ombi requests?
+
+Both work together seamlessly. qBitrr will process all requests from Overseerr/Ombi, whether they originated from Requestrr, the web interface, or any other source.
+
+## Troubleshooting
+
+### Requests from Requestrr not appearing in qBitrr
+
+1. Verify Requestrr is connected to Overseerr/Ombi (check Requestrr logs)
+2. Verify Overseerr/Ombi is connected to Radarr/Sonarr/Lidarr
+3. Verify qBitrr is connected to the same Overseerr/Ombi instance
+4. Check qBitrr logs for connection errors
+
+### Requestrr can't connect to Overseerr/Ombi
+
+1. Verify Overseerr/Ombi is running and accessible
+2. Check API key is correct in Requestrr settings
+3. Verify network connectivity between containers
+4. Check for CSRF protection issues (Overseerr requires CSRF to be disabled for Requestrr)
+
+## Related Documentation
+
+- [Overseerr Integration](overseerr.md) - Configure Overseerr backend
+- [Ombi Integration](ombi.md) - Configure Ombi backend
+- [Search Configuration](index.md) - General search settings
+- [Request Integration](../../features/request-integration.md) - Request system overview
+- [Requestrr Wiki](https://github.com/thomst08/requestrr/wiki) - Requestrr documentation

--- a/docs/features/request-integration.md
+++ b/docs/features/request-integration.md
@@ -48,6 +48,23 @@ Request integration allows qBitrr to:
 
 ---
 
+### Requestrr
+
+**Discord chatbot for media requests**
+
+Requestrr provides a Discord interface for users to request content. To integrate with qBitrr, configure Requestrr to use **Overseerr or Ombi** as its backend - qBitrr will automatically process those requests.
+
+- ✅ **Discord Integration**: Users request via Discord
+- ✅ **Via Overseerr**: Full feature support (recommended)
+- ✅ **Via Ombi**: Alternative backend support
+- ⚠️ **No Direct qBitrr Support**: Must use Overseerr or Ombi as backend
+
+**Use Case:** Discord-based request workflows
+
+[**→ Requestrr Integration Guide**](../configuration/search/requestrr.md)
+
+---
+
 ## How It Works
 
 ### Request Flow


### PR DESCRIPTION
## Summary

This PR adds documentation for integrating Requestrr with qBitrr via Overseerr or Ombi.

## Changes

### New Documentation
- **docs/configuration/search/requestrr.md**: New main documentation file explaining:
  - How Requestrr works (Discord chatbot, no database)
  - The architecture: Requestrr → Overseerr/Ombi → qBitrr
  - Setup instructions for Requestrr, Overseerr/Ombi, and qBitrr
  - Docker Compose example
  - FAQ and troubleshooting

### Updated Documentation
- **docs/configuration/search/overseerr.md**: Added tip box linking to Requestrr docs
- **docs/configuration/search/ombi.md**: Added tip box linking to Requestrr docs
- **docs/configuration/search/index.md**: Added Requestrr to supported systems table
- **docs/features/request-integration.md**: Added Requestrr section to supported systems

## Key Points

1. Requestrr is a Discord chatbot - it forwards requests to Overseerr or Ombi
2. qBitrr integrates with Requestrr **through** Overseerr or Ombi (not directly)
3. All requests from Overseerr/Ombi are processed equally, regardless of source
4. No code changes required - existing Overseerr/Ombi integration handles it

## Related

Closes #280