### PR TITLE
Fix config editor UX (#422) and add WebUI UrlBase support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -98,6 +98,10 @@ AuthDisabled = true
 # When true, the app trusts X-Forwarded-Proto and sets the session cookie as Secure. Leave false for plain HTTP.
 BehindHttpsProxy = false
 
+# Public URL path prefix when served behind a reverse proxy (no trailing slash).
+# Example: "/qbitrr" serves the UI at https://host/qbitrr/ui. Leave empty for site root.
+UrlBase = ""
+
 # Enable username/password login
 LocalAuthEnabled = false
 

--- a/docs/configuration/webui.md
+++ b/docs/configuration/webui.md
@@ -260,6 +260,37 @@ BehindHttpsProxy = true
 
 ---
 
+## UrlBase
+
+```toml
+UrlBase = ""
+```
+
+**Type:** String (URL path)
+**Default:** `""` (site root)
+
+Public path prefix when qBitrr is served behind a reverse proxy on a subpath instead of a dedicated subdomain.
+
+**Examples:**
+
+| UrlBase | UI URL |
+|---------|--------|
+| `""` | `https://host/ui` |
+| `"/qbitrr"` | `https://host/qbitrr/ui` |
+
+**Rules:**
+
+- Must start with `/` when set (e.g. `/qbitrr`, not `qbitrr`)
+- Must **not** end with a trailing slash
+- Set this to match the path your reverse proxy exposes publicly
+
+When `UrlBase` is set, qBitrr prefixes redirects, session cookies, OIDC callback URLs, and WebUI API calls accordingly. The React app reads the prefix from the page URL and `/web/meta`.
+
+!!! tip "OIDC under a subpath"
+    Register the redirect URI as `https://your-host<UrlBase><CallbackPath>` — for example `https://example.com/qbitrr/signin-oidc` when `UrlBase = "/qbitrr"` and `CallbackPath = "/signin-oidc"`.
+
+---
+
 ## LiveArr
 
 ```toml
@@ -403,12 +434,14 @@ ViewDensity = "Comfortable"
 
 ---
 
-### Example 3: Localhost Only (with Reverse Proxy)
+### Example 3: Subpath Behind Reverse Proxy
 
 ```toml
 [WebUI]
 Host = "127.0.0.1"
 Port = 6969
+UrlBase = "/qbitrr"
+BehindHttpsProxy = true
 Token = ""  # Reverse proxy handles auth
 LiveArr = true
 GroupSonarr = true
@@ -417,17 +450,21 @@ Theme = "Dark"
 ViewDensity = "Comfortable"
 ```
 
-**Nginx reverse proxy:**
+**Nginx reverse proxy** (prefix-stripping `proxy_pass` — most common):
 
 ```nginx
 location /qbitrr/ {
     proxy_pass http://127.0.0.1:6969/;
     proxy_set_header Host $host;
     proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
 }
 ```
 
 **Access:** `https://yourdomain.com/qbitrr/ui`
+
+`UrlBase` must match the public path (`/qbitrr`). Nginx strips the prefix before forwarding to qBitrr; the app still generates browser-facing URLs under `/qbitrr/...`.
 
 ---
 
@@ -450,7 +487,14 @@ Theme = "Dark"
 
 ## Reverse Proxy Configuration
 
-### Nginx
+### Subpath vs dedicated host
+
+| Deployment | `UrlBase` | Typical proxy |
+|------------|-----------|---------------|
+| Dedicated host (`qbitrr.example.com`) | `""` | `location / { proxy_pass http://127.0.0.1:6969; }` |
+| Shared host subpath (`example.com/qbitrr`) | `"/qbitrr"` | `location /qbitrr/ { proxy_pass http://127.0.0.1:6969/; }` |
+
+### Nginx (dedicated host)
 
 ```nginx
 server {

--- a/docs/development/webui.md
+++ b/docs/development/webui.md
@@ -16,7 +16,9 @@ npm run dev
 # Visit http://localhost:5173
 ```
 
-The development server proxies API requests to http://localhost:6969 where qBitrr backend should be running.
+The development server proxies `/web`, `/api`, `/ui`, `/static`, and related paths to `http://127.0.0.1:6969` where the qBitrr backend should be running.
+
+For subpath deployments (`WebUI.UrlBase`), test against the built bundle served by Flask (`npm run build`, then open `http://localhost:6969/ui` or `http://localhost:6969/qbitrr/ui` with `UrlBase` set) rather than the Vite dev server alone.
 
 ## Tech Stack
 
@@ -26,8 +28,8 @@ The development server proxies API requests to http://localhost:6969 where qBitr
 - **TypeScript** - Type-safe JavaScript
 - **Vite** - Fast build tool with HMR
 - **Mantine v8** - Component library
-- **React Router** - Client-side routing
-- **Axios** - HTTP client
+- **fetch API** - HTTP client (`src/api/client.ts`)
+- **urlBase helper** - Prefixes API paths when `WebUI.UrlBase` is set (`src/api/urlBase.ts`)
 
 ### State Management
 
@@ -54,7 +56,8 @@ webui/
 │   └── ...
 ├── src/
 │   ├── api/                # API client
-│   │   ├── client.ts       # Axios instance
+│   │   ├── client.ts       # fetch wrapper
+│   │   ├── urlBase.ts      # UrlBase path prefix helper
 │   │   └── types.ts        # TypeScript interfaces
 │   ├── components/         # Reusable components
 │   │   ├── ConfirmDialog.tsx

--- a/docs/webui/config-editor.md
+++ b/docs/webui/config-editor.md
@@ -534,7 +534,7 @@ Numeric field with spinner controls.
 ```
 
 ### Duration Input
-Time fields use a **number input plus unit dropdown** (s, m, h, d, w, M) instead of raw seconds or minutes. When you change a duration and save, the config may store it as a suffixed string (e.g. `MaxSeedingTime = "1w"`, `StalledDelay = "60m"`) for readability; the backend accepts both integers and suffixed strings. Disabled values (e.g. `-1`) appear as "Disabled" where supported.
+Time fields use a **number input plus unit dropdown** (s, m, h, d, w, M) instead of raw seconds or minutes. When you change a duration and save, the config may store it as a suffixed string (e.g. `MaxSeedingTime = "1w"`, `StalledDelay = "60m"`) for readability; the backend accepts both integers and suffixed strings. Disabled values (`-1`) show an empty field with a **Disabled** placeholder; use **Use disabled** or clear the field and blur to set disabled again.
 
 ### Checkbox
 Toggle boolean values.
@@ -642,13 +642,22 @@ Radarr-4K.URI: URI must be set to a valid URL when the instance is managed.
 
 ## Save Behavior and Live Reload
 
+### Per-Instance Save
+
+Each qBittorrent instance (`qBit`, `qBit-1`, …) and each Arr instance (`Radarr-4K`, `Sonarr-TV`, `Lidarr-Music`, …) has its own **Save** button on the instance card and inside the configure modal. Use this to persist one instance without validating or saving unrelated instances.
+
+- **Per-instance Save** validates only that instance (skipped when Arr `Managed = false` or qBit `Disabled = true`)
+- **Save + Live Reload** at the bottom saves all changed sections and validates only sections with pending changes
+
+Core blocks (**Settings**, **Web Settings**, **Authentication**) are included in **Save + Live Reload** only.
+
 ### Save Process
 
-When you click **Save + Live Reload**:
+When you click **Save** on an instance card or **Save + Live Reload**:
 
-1. **Client-Side Validation**: All fields validated; save blocked if errors exist
+1. **Client-Side Validation**: Only the target instance (or changed sections for global save) is validated; save blocked if errors exist
 2. **Change Detection**: Compares current form state vs. original config
-3. **Diff Calculation**: Generates minimal change set (only modified fields)
+3. **Diff Calculation**: Generates minimal change set (only modified fields for that instance or all dirty keys)
 4. **API Request**: `POST /api/config` with `{"changes": {...}}`
 5. **Server-Side Validation**: Backend validates and persists to `config.toml`
 6. **Reload Detection**: Server determines which components need reloading
@@ -696,22 +705,21 @@ Attempts to modify protected keys return `403 Forbidden`.
 
 ## Modal State Persistence
 
-Configuration modals now preserve their state when you switch tabs or windows:
+Configuration modals preserve their state while you work in the Config tab:
 
 **Persistent State**:
 
-- **Open Modals**: Remain open when switching between tabs or minimizing the browser
-- **Entered Data**: All field values are preserved across tab switches
-- **Unsaved Changes**: Maintained even if you switch to another application
+- **Open Modals**: Remain open while you stay on the Config tab
+- **Entered Data**: All field values are preserved until you save or reload config
+- **Unsaved Changes**: Prompted when leaving Config via another tab if changes exist
 
-**Benefits**:
+**Interaction Safety**:
 
-- Fill out long configuration forms without losing progress
-- Reference other applications while configuring
-- Switch tabs to check settings in other systems
-- Resume configuration exactly where you left off
+- Modals ignore accidental clicks after text selection (e.g. releasing the mouse over Close after highlighting a field)
+- **Escape** closes modals unless focus is in an input, textarea, or select
+- Instance modals render as a full-screen overlay so they are not obscured by page navigation
 
-**Note**: Modal state is preserved only within the Config tab. Navigating to a different WebUI page (Processes, Logs, etc.) will close modals as expected.
+**Note**: Switching to another WebUI tab (Processes, Logs, etc.) unmounts the Config page and closes modals. You are prompted to confirm if unsaved changes exist.
 
 ---
 

--- a/docs/webui/index.md
+++ b/docs/webui/index.md
@@ -360,7 +360,8 @@ Edit your qBitrr configuration without leaving the browser.
   - Download configuration file
 
 - **Apply Changes**
-  - Save configuration
+  - Per-instance save for each qBittorrent and Arr instance
+  - Save all changed sections with **Save + Live Reload**
   - Restart qBitrr with new config
   - Restart specific Arr instances only
   - Rollback on failure

--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -6742,7 +6742,12 @@ class Arr:
         if tracker_set_changed:
             self._torrent_important_trackers_cache.pop(torrent.hash, None)
             # Tracker membership changed (add/remove), so recompute from fresh data.
-            _, monitored_trackers = self._get_torrent_important_trackers(torrent, use_cache=False)
+            try:
+                _, monitored_trackers = self._get_torrent_important_trackers(
+                    torrent, use_cache=False
+                )
+            except _TrackerDataUnavailable:
+                return
         most_important_tracker, unique_tags = self._get_most_important_tracker_and_tags(
             monitored_trackers, _remove_urls
         )

--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -7903,6 +7903,15 @@ class Arr:
                     self.db_maybe_reset_entry_searched_state()
                     self.refresh_download_queue()
                     self.db_update()
+                    # Reset the loop timer after db_update() so that the time
+                    # spent ingesting the library does not count toward
+                    # loop_timer. For large libraries (e.g. a big Lidarr music
+                    # library) db_update() can take much longer than loop_timer,
+                    # in which case ``now >= timer + loop_timer`` is already true
+                    # by the time ingestion finishes and RestartLoopException is
+                    # raised before db_get_files()/maybe_do_search() ever runs --
+                    # starving missing-search entirely for that instance.
+                    timer = datetime.now()
 
                     # Check for expired temp profiles if feature is enabled
                     if self.use_temp_for_missing and self.temp_profile_timeout_minutes > 0:

--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -604,6 +604,7 @@ class Arr:
         self.resume = set()
         self.remove_from_qbit = set()
         self.remove_from_qbit_by_instance: dict[str, set[str]] = {}
+        self.delete_by_instance: dict[str, set[str]] = {}
         self.overseerr_requests_release_cache = {}
         self.files_to_explicitly_delete: Iterator = iter([])
         self.files_to_cleanup = set()
@@ -1999,15 +2000,17 @@ class Arr:
         n_bad_msg = len(self.downloads_with_bad_error_message_blocklist)
         n_remove = len(self.remove_from_qbit)
         n_remove_by_inst = sum(len(s) for s in self.remove_from_qbit_by_instance.values())
+        n_delete_by_inst = sum(len(s) for s in self.delete_by_instance.values())
         n_skip = len(self.skip_blacklist)
         self.logger.info(
             "Deletion summary: delete=%d, missing_files=%d, bad_error_blocklist=%d, "
-            "remove_from_qbit=%d, remove_by_instance=%d, skip_blacklist=%d",
+            "remove_from_qbit=%d, remove_by_instance=%d, delete_by_instance=%d, skip_blacklist=%d",
             n_delete,
             n_missing,
             n_bad_msg,
             n_remove,
             n_remove_by_inst,
+            n_delete_by_inst,
             n_skip,
         )
 
@@ -2069,16 +2072,24 @@ class Arr:
             or self.remove_from_qbit
             or self.skip_blacklist
             or self.remove_from_qbit_by_instance
+            or self.delete_by_instance
         ):
             self._log_deletion_summary_line()
             self._log_deletion_sample_debug(to_delete_all)
         self._process_failed_dispatch_queue_deletes(to_delete_all, skip_blacklist, cross_arr=False)
-        # Delete missing-files torrents from the correct qBit instance (multi-instance).
+        # Delete torrents from the correct qBit instance (multi-instance).
+        per_instance_batches: dict[str, set[str]] = {}
+        for inst_name, hashes in self.remove_from_qbit_by_instance.items():
+            if hashes:
+                per_instance_batches.setdefault(inst_name, set()).update(hashes)
+        for inst_name, hashes in self.delete_by_instance.items():
+            if hashes:
+                per_instance_batches.setdefault(inst_name, set()).update(hashes)
         per_instance_hashes = set()
-        for hashes in self.remove_from_qbit_by_instance.values():
+        for hashes in per_instance_batches.values():
             per_instance_hashes.update(hashes)
         qbit_manager = self.manager.qbit_manager
-        for inst_name, hashes in self.remove_from_qbit_by_instance.items():
+        for inst_name, hashes in per_instance_batches.items():
             client = qbit_manager.get_client(inst_name)
             if client is None:
                 self.logger.warning(
@@ -2100,6 +2111,7 @@ class Arr:
                     e,
                 )
         self.remove_from_qbit_by_instance.clear()
+        self.delete_by_instance.clear()
         to_delete_all = to_delete_all - per_instance_hashes
         if self.remove_from_qbit or self.skip_blacklist or to_delete_all:
             # Remove all bad torrents from the Client.
@@ -5740,8 +5752,10 @@ class Arr:
         # If we reach here, all recovery methods failed
         raise DatabaseRecoveryError("All automatic recovery methods failed")
 
-    def _process_single_torrent_failed_cat(self, torrent: qbittorrentapi.TorrentDictionary):
-        self._mark_for_deletion(torrent, "manually failed")
+    def _process_single_torrent_failed_cat(
+        self, torrent: qbittorrentapi.TorrentDictionary, instance_name: str = "default"
+    ):
+        self._mark_for_deletion(torrent, "manually failed", instance_name=instance_name)
 
     def _process_single_torrent_recheck_cat(self, torrent: qbittorrentapi.TorrentDictionary):
         self.logger.notice(
@@ -5767,6 +5781,7 @@ class Arr:
         reason: str,
         ratio_limit=None,
         seeding_time_limit=None,
+        instance_name: str = "default",
     ) -> None:
         """Mark torrent for deletion and log reason with current stats and effective limits."""
         extra = ""
@@ -5791,6 +5806,7 @@ class Arr:
             extra,
         )
         self.delete.add(torrent.hash)
+        self.delete_by_instance.setdefault(instance_name, set()).add(torrent.hash)
 
     def _process_single_torrent_ignored(self, torrent: qbittorrentapi.TorrentDictionary):
         # Do not touch torrents that are currently being ignored.
@@ -5867,7 +5883,10 @@ class Arr:
             )
 
     def _process_single_torrent_stalled_torrent(
-        self, torrent: qbittorrentapi.TorrentDictionary, extra: str
+        self,
+        torrent: qbittorrentapi.TorrentDictionary,
+        extra: str,
+        instance_name: str = "default",
     ):
         # Process torrents who have stalled at this point, only mark for
         # deletion if they have been added more than "IgnoreTorrentsYoungerThan"
@@ -5877,7 +5896,7 @@ class Arr:
             and torrent.last_activity < (time.time() - self.ignore_torrents_younger_than)
         ):
             if self._hnr_allows_delete(torrent, extra):
-                self._mark_for_deletion(torrent, extra)
+                self._mark_for_deletion(torrent, extra, instance_name=instance_name)
         else:
             self.logger.trace(
                 "Ignoring Stale torrent (%s): "
@@ -5897,7 +5916,10 @@ class Arr:
             )
 
     def _process_single_torrent_percentage_threshold(
-        self, torrent: qbittorrentapi.TorrentDictionary, maximum_eta: int
+        self,
+        torrent: qbittorrentapi.TorrentDictionary,
+        maximum_eta: int,
+        instance_name: str = "default",
     ):
         # Ignore torrents who have reached maximum percentage as long as
         # the last activity is within the MaximumETA set for this category
@@ -5911,7 +5933,9 @@ class Arr:
         # remove it and requeue a new torrent.
         if maximum_eta > 0 and torrent.last_activity < (time.time() - maximum_eta):
             if self._hnr_allows_delete(torrent, "stale high-percentage deletion"):
-                self._mark_for_deletion(torrent, "stale high-percentage deletion")
+                self._mark_for_deletion(
+                    torrent, "stale high-percentage deletion", instance_name=instance_name
+                )
         else:
             self.logger.trace(
                 "Skipping torrent: Reached Maximum completed "
@@ -6118,7 +6142,9 @@ class Arr:
             torrent.hash,
         )
 
-    def _process_single_torrent_delete_slow(self, torrent: qbittorrentapi.TorrentDictionary):
+    def _process_single_torrent_delete_slow(
+        self, torrent: qbittorrentapi.TorrentDictionary, instance_name: str = "default"
+    ):
         self.logger.trace(
             "Deleting slow torrent: "
             "[Progress: %s%%][Added On: %s]"
@@ -6135,18 +6161,21 @@ class Arr:
             torrent.hash,
         )
         if self._hnr_allows_delete(torrent, "slow torrent deletion"):
-            self._mark_for_deletion(torrent, "slow torrent deletion")
+            self._mark_for_deletion(torrent, "slow torrent deletion", instance_name=instance_name)
 
     def _process_single_torrent_delete_cfunmet(
         self, torrent: qbittorrentapi.TorrentDictionary, instance_name: str = ""
     ):
         if self._hnr_allows_delete(torrent, "CF unmet deletion"):
-            self._mark_for_deletion(torrent, "CF unmet deletion")
+            self._mark_for_deletion(
+                torrent, "CF unmet deletion", instance_name=instance_name or "default"
+            )
 
     def _process_single_torrent_delete_ratio_seed(
         self,
         torrent: qbittorrentapi.TorrentDictionary,
         limit_meta: tuple[dict, dict] | None = None,
+        instance_name: str = "default",
     ):
         if limit_meta is not None:
             data_settings, data_torrent = limit_meta
@@ -6175,10 +6204,14 @@ class Arr:
                 "ratio/seed limit deletion",
                 ratio_limit=ratio_limit,
                 seeding_time_limit=seeding_time_limit,
+                instance_name=instance_name,
             )
 
     def _process_single_torrent_process_files(
-        self, torrent: qbittorrentapi.TorrentDictionary, special_case: bool = False
+        self,
+        torrent: qbittorrentapi.TorrentDictionary,
+        special_case: bool = False,
+        instance_name: str = "default",
     ):
         _remove_files = set()
         total = len(torrent.files)
@@ -6242,7 +6275,9 @@ class Arr:
             # torrent.
             if total == 0:
                 if self._hnr_allows_delete(torrent, "all-files-excluded deletion"):
-                    self._mark_for_deletion(torrent, "all-files-excluded deletion")
+                    self._mark_for_deletion(
+                        torrent, "all-files-excluded deletion", instance_name=instance_name
+                    )
             # Mark all bad files and folder for exclusion.
             elif _remove_files and torrent.hash not in self.change_priority:
                 self.change_priority[torrent.hash] = list(_remove_files)
@@ -6908,13 +6943,20 @@ class Arr:
             and not self.in_tags(torrent, "qBitrr-free_space_paused", instance_name)
         ):
             self._process_single_torrent_delete_cfunmet(torrent, instance_name)
-        elif remove_torrent and not leave_alone and torrent.amount_left == 0:
+        elif (
+            remove_torrent
+            and not leave_alone
+            and torrent.amount_left == 0
+            and not self.in_tags(torrent, "qBitrr-ignored", instance_name)
+        ):
             self._process_single_torrent_delete_ratio_seed(
-                torrent, limit_meta=(_data_settings, _data_torrent)
+                torrent,
+                limit_meta=(_data_settings, _data_torrent),
+                instance_name=instance_name,
             )
         elif torrent.category == FAILED_CATEGORY:
             # Bypass everything if manually marked as failed
-            self._process_single_torrent_failed_cat(torrent)
+            self._process_single_torrent_failed_cat(torrent, instance_name)
         elif torrent.category == RECHECK_CATEGORY:
             # Bypass everything else if manually marked for rechecking
             self._process_single_torrent_recheck_cat(torrent)
@@ -6942,14 +6984,14 @@ class Arr:
             and not self.in_tags(torrent, "qBitrr-free_space_paused", instance_name)
             and not stalled_ignore
         ):
-            self._process_single_torrent_stalled_torrent(torrent, "Stalled State")
+            self._process_single_torrent_stalled_torrent(torrent, "Stalled State", instance_name)
         elif (
             torrent.state_enum.is_downloading
             and torrent.state_enum != TorrentStates.METADATA_DOWNLOAD
             and torrent.hash not in self.special_casing_file_check
             and torrent.hash not in self.cleaned_torrents
         ):
-            self._process_single_torrent_process_files(torrent, True)
+            self._process_single_torrent_process_files(torrent, True, instance_name)
         elif torrent.hash in self.timed_ignore_cache:
             if (
                 torrent.state_enum
@@ -6983,7 +7025,9 @@ class Arr:
             and not self.in_tags(torrent, "qBitrr-free_space_paused", instance_name)
             and not stalled_ignore
         ) and torrent.hash in self.cleaned_torrents:
-            self._process_single_torrent_percentage_threshold(torrent, maximum_eta)
+            self._process_single_torrent_percentage_threshold(
+                torrent, maximum_eta, instance_name
+            )
         # Ignore torrents which have been submitted to their respective Arr
         # instance for import. Resolve the owning category through ArrManager so
         # subcategory paths (``seed/tleech``) and orphaned categories don't raise
@@ -7039,7 +7083,7 @@ class Arr:
             and not self.in_tags(torrent, "qBitrr-free_space_paused", instance_name)
             and not stalled_ignore
         ):
-            self._process_single_torrent_delete_slow(torrent)
+            self._process_single_torrent_delete_slow(torrent, instance_name)
         # Process uncompleted torrents
         elif torrent.state_enum.is_downloading:
             # If a torrent availability hasn't reached 100% or more within the configurable
@@ -7055,13 +7099,15 @@ class Arr:
                 and not self.in_tags(torrent, "qBitrr-free_space_paused", instance_name)
                 and not stalled_ignore
             ):
-                self._process_single_torrent_stalled_torrent(torrent, "Unavailable")
+                self._process_single_torrent_stalled_torrent(
+                    torrent, "Unavailable", instance_name
+                )
             else:
                 if torrent.hash in self.cleaned_torrents:
                     self._process_single_torrent_already_cleaned_up(torrent)
                     return
                 # A downloading torrent is not stalled, parse its contents.
-                self._process_single_torrent_process_files(torrent)
+                self._process_single_torrent_process_files(torrent, instance_name=instance_name)
         elif self.is_complete_state(torrent) and leave_alone:
             self._process_single_completed_paused_torrent(torrent, leave_alone)
         else:
@@ -8132,6 +8178,7 @@ class PlaceHolderArr(Arr):
         self.skip_blacklist = set()
         self.remove_from_qbit = set()
         self.remove_from_qbit_by_instance: dict[str, set[str]] = {}
+        self.delete_by_instance: dict[str, set[str]] = {}
         self.delete = set()
         self.resume = set()
         self.expiring_bool = ExpiringSet(max_age_seconds=10)
@@ -8304,6 +8351,7 @@ class PlaceHolderArr(Arr):
             or self.remove_from_qbit
             or self.skip_blacklist
             or self.remove_from_qbit_by_instance
+            or self.delete_by_instance
         ):
             return
         self._log_deletion_summary_line()
@@ -8311,8 +8359,18 @@ class PlaceHolderArr(Arr):
         self._process_failed_dispatch_queue_deletes(to_delete_all, skip_blacklist, cross_arr=True)
         deleted_hashes: set[str] = set()
         qbit_manager = self.manager.qbit_manager
-        # Delete per-instance (e.g. missing-files) so we use the correct qBit client.
-        for instance_name, hashes in self.remove_from_qbit_by_instance.items():
+        per_instance_batches: dict[str, set[str]] = {}
+        for inst_name, hashes in self.remove_from_qbit_by_instance.items():
+            if hashes:
+                per_instance_batches.setdefault(inst_name, set()).update(hashes)
+        for inst_name, hashes in self.delete_by_instance.items():
+            if hashes:
+                per_instance_batches.setdefault(inst_name, set()).update(hashes)
+        per_instance_hashes = set()
+        for hashes in per_instance_batches.values():
+            per_instance_hashes.update(hashes)
+        # Delete per-instance so we use the correct qBit client.
+        for instance_name, hashes in per_instance_batches.items():
             client = qbit_manager.get_client(instance_name)
             if client is None:
                 self.logger.warning(
@@ -8337,6 +8395,7 @@ class PlaceHolderArr(Arr):
                     instance_name,
                     e,
                 )
+        to_delete_all = to_delete_all - per_instance_hashes
         # Remaining remove_from_qbit/skip_blacklist and to_delete_all via default client.
         if self.remove_from_qbit or self.skip_blacklist or to_delete_all:
             temp_to_delete = set()
@@ -8396,6 +8455,7 @@ class PlaceHolderArr(Arr):
         self.skip_blacklist.clear()
         self.remove_from_qbit.clear()
         self.remove_from_qbit_by_instance.clear()
+        self.delete_by_instance.clear()
         self.delete.clear()
 
     def _process_errored(self):

--- a/qBitrr/gen_config.py
+++ b/qBitrr/gen_config.py
@@ -61,6 +61,15 @@ def _add_web_settings_section(config: TOMLDocument):
     )
     _gen_default_line(
         web_settings,
+        [
+            "Public URL path prefix when served behind a reverse proxy (no trailing slash).",
+            'Example: "/qbitrr" serves the UI at https://host/qbitrr/ui. Leave empty for site root.',
+        ],
+        "UrlBase",
+        "",
+    )
+    _gen_default_line(
+        web_settings,
         "Enable username/password login",
         "LocalAuthEnabled",
         False,
@@ -1736,6 +1745,18 @@ def _normalize_theme_value(value: Any) -> str:
         return "Dark"
 
 
+def _normalize_url_base_value(value: Any) -> str:
+    """Normalize WebUI.UrlBase to '' or a leading-slash path without trailing slash."""
+    if value is None:
+        return ""
+    raw = str(value).strip()
+    if not raw:
+        return ""
+    if not raw.startswith("/"):
+        raw = f"/{raw}"
+    return raw.rstrip("/")
+
+
 def _normalize_view_density_value(value: Any) -> str:
     """
     Normalize view density value to always be 'Comfortable' or 'Compact' (case insensitive input).
@@ -1819,6 +1840,7 @@ def _validate_and_fill_config(config: MyConfig) -> bool:
         ("Port", 6969),
         ("Token", ""),
         ("BehindHttpsProxy", False),
+        ("UrlBase", ""),
         ("LiveArr", True),
         ("GroupSonarr", True),
         ("GroupLidarr", True),
@@ -1846,6 +1868,13 @@ def _validate_and_fill_config(config: MyConfig) -> bool:
         normalized_density = _normalize_view_density_value(current_density)
         if current_density != normalized_density:
             webui_section["ViewDensity"] = normalized_density
+            changed = True
+
+    if "UrlBase" in webui_section:
+        current_url_base = webui_section["UrlBase"]
+        normalized_url_base = _normalize_url_base_value(current_url_base)
+        if current_url_base != normalized_url_base:
+            webui_section["UrlBase"] = normalized_url_base
             changed = True
 
     # Validate qBit section

--- a/qBitrr/webui.py
+++ b/qBitrr/webui.py
@@ -65,6 +65,61 @@ def configured_url_base() -> str:
     return normalize_url_base(CONFIG.get("WebUI.UrlBase", fallback=""))
 
 
+def _forwarded_url_prefix(environ: dict[str, Any]) -> str:
+    """Read public path prefix set by a reverse proxy (strip-mode deployments)."""
+    for header in ("HTTP_X_FORWARDED_PREFIX", "HTTP_X_SCRIPT_NAME"):
+        raw = environ.get(header, "")
+        if not raw:
+            continue
+        return normalize_url_base(raw.split(",")[0].strip())
+    return ""
+
+
+def _merge_script_name(environ: dict[str, Any], prefix: str) -> None:
+    """Set SCRIPT_NAME so Flask generates browser-facing URLs under UrlBase."""
+    if not prefix:
+        return
+    existing = environ.get("SCRIPT_NAME", "").rstrip("/")
+    if existing == prefix or existing.endswith(prefix):
+        return
+    environ["SCRIPT_NAME"] = f"{existing}{prefix}" if existing else prefix
+
+
+class UrlBaseMiddleware:
+    """Normalize UrlBase for WSGI: strip incoming prefix or honor proxy strip headers."""
+
+    def __init__(self, app: Any) -> None:
+        self._app = app
+
+    def __call__(self, environ: dict[str, Any], start_response: Any) -> Any:
+        prefix = configured_url_base()
+        path = environ.get("PATH_INFO", "") or "/"
+        if not prefix:
+            return self._app(environ, start_response)
+
+        forwarded_prefix = _forwarded_url_prefix(environ)
+        if path == prefix or path.startswith(f"{prefix}/"):
+            _merge_script_name(environ, prefix)
+            stripped = path[len(prefix) :]
+            environ["PATH_INFO"] = stripped or "/"
+        elif forwarded_prefix == prefix:
+            _merge_script_name(environ, prefix)
+        return self._app(environ, start_response)
+
+
+def _unwrap_url_base_middleware(wsgi_app: Any) -> Any:
+    """Return the WSGI app below any stacked UrlBaseMiddleware layers."""
+    while isinstance(wsgi_app, UrlBaseMiddleware):
+        wsgi_app = wsgi_app._app
+    return wsgi_app
+
+
+def _install_url_base_middleware(app: Flask) -> None:
+    """Ensure exactly one UrlBaseMiddleware wraps the current WSGI stack."""
+    inner = _unwrap_url_base_middleware(app.wsgi_app)
+    app.wsgi_app = UrlBaseMiddleware(inner)
+
+
 def _openapi_path_in_api_first_spec(path: str) -> bool:
     """Paths exposed in the filtered OpenAPI doc (Swagger): `/api/*` plus mirrored poster thumbnails."""
     if not path.startswith("/web/"):
@@ -317,6 +372,9 @@ class WebUI:
         self.host = host
         self.port = port
         self.app = Flask(__name__)
+        url_base = configured_url_base()
+        if url_base:
+            self.app.config["APPLICATION_ROOT"] = url_base
         self.logger = logging.getLogger("qBitrr.WebUI")
         run_logs(self.logger, "WebUI")
         self.logger.info("Initialising WebUI on %s:%s", self.host, self.port)
@@ -347,25 +405,7 @@ class WebUI:
 
             self.app.wsgi_app = ProxyFix(self.app.wsgi_app, x_for=1, x_proto=1)
 
-        class _UrlBaseMiddleware:
-            """Strip configured UrlBase prefix when the proxy forwards it to Flask."""
-
-            def __init__(self, app, prefix: str):
-                self._app = app
-                self._prefix = prefix
-
-            def __call__(self, environ, start_response):
-                if self._prefix:
-                    path = environ.get("PATH_INFO", "")
-                    if path == self._prefix or path.startswith(f"{self._prefix}/"):
-                        environ["SCRIPT_NAME"] = (
-                            f"{environ.get('SCRIPT_NAME', '')}{self._prefix}".rstrip("/")
-                        )
-                        stripped = path[len(self._prefix) :]
-                        environ["PATH_INFO"] = stripped or "/"
-                return self._app(environ, start_response)
-
-        self.app.wsgi_app = _UrlBaseMiddleware(self.app.wsgi_app, configured_url_base())
+        _install_url_base_middleware(self.app)
 
         # Add cache control and security headers
         @self.app.after_request
@@ -2126,13 +2166,13 @@ class WebUI:
         def api_swagger_docs():
             if (resp := require_token()) is not None:
                 return resp
-            return _swagger_ui_response("/api/openapi.json")
+            return _swagger_ui_response(_public_url("/api/openapi.json"))
 
         @app.get("/web/docs")
         def web_swagger_docs():
             if (resp := require_token()) is not None:
                 return resp
-            return _swagger_ui_response("/web/openapi.json")
+            return _swagger_ui_response(_public_url("/web/openapi.json"))
 
         @app.get("/ui")
         def ui_index():
@@ -4126,6 +4166,16 @@ class WebUI:
             # Clear rebuilding flag
             self._rebuilding_arrs = False
 
+    def _apply_webui_runtime_settings(self) -> None:
+        """Refresh UrlBase middleware and session cookie path from current config."""
+        _install_url_base_middleware(self.app)
+        url_base = configured_url_base()
+        if url_base:
+            self.app.config["APPLICATION_ROOT"] = url_base
+        else:
+            self.app.config.pop("APPLICATION_ROOT", None)
+        self.app.config["SESSION_COOKIE_PATH"] = f"{url_base}/" if url_base else "/"
+
     def _restart_webui(self):
         """
         Gracefully restart the WebUI server without affecting Arr processes.
@@ -4143,6 +4193,9 @@ class WebUI:
         new_host = CONFIG.get("WebUI.Host", fallback="0.0.0.0")
         new_port = CONFIG.get("WebUI.Port", fallback=6969)
         new_token = CONFIG.get("WebUI.Token", fallback=None)
+
+        # UrlBase and related settings apply without binding a new port
+        self._apply_webui_runtime_settings()
 
         # Check if restart is actually needed
         needs_restart = new_host != self.host or new_port != self.port

--- a/qBitrr/webui.py
+++ b/qBitrr/webui.py
@@ -48,6 +48,23 @@ _openapi_spec: dict[str, Any] | None = None
 _openapi_spec_api_only: dict[str, Any] | None = None
 
 
+def normalize_url_base(value: str | None) -> str:
+    """Normalize WebUI.UrlBase to '' or a leading-slash path without trailing slash."""
+    if not value:
+        return ""
+    raw = str(value).strip()
+    if not raw:
+        return ""
+    if not raw.startswith("/"):
+        raw = f"/{raw}"
+    return raw.rstrip("/")
+
+
+def configured_url_base() -> str:
+    """Return the configured public URL path prefix for the WebUI."""
+    return normalize_url_base(CONFIG.get("WebUI.UrlBase", fallback=""))
+
+
 def _openapi_path_in_api_first_spec(path: str) -> bool:
     """Paths exposed in the filtered OpenAPI doc (Swagger): `/api/*` plus mirrored poster thumbnails."""
     if not path.startswith("/web/"):
@@ -330,21 +347,25 @@ class WebUI:
 
             self.app.wsgi_app = ProxyFix(self.app.wsgi_app, x_for=1, x_proto=1)
 
-        class _QbitrrPrefixMiddleware:
-            """Support both / and /qbitrr path topologies behind reverse proxies."""
+        class _UrlBaseMiddleware:
+            """Strip configured UrlBase prefix when the proxy forwards it to Flask."""
 
-            def __init__(self, app):
+            def __init__(self, app, prefix: str):
                 self._app = app
+                self._prefix = prefix
 
             def __call__(self, environ, start_response):
-                path = environ.get("PATH_INFO", "")
-                if path == "/qbitrr" or path.startswith("/qbitrr/"):
-                    environ["SCRIPT_NAME"] = f"{environ.get('SCRIPT_NAME', '')}/qbitrr".rstrip("/")
-                    stripped = path[len("/qbitrr") :]
-                    environ["PATH_INFO"] = stripped or "/"
+                if self._prefix:
+                    path = environ.get("PATH_INFO", "")
+                    if path == self._prefix or path.startswith(f"{self._prefix}/"):
+                        environ["SCRIPT_NAME"] = (
+                            f"{environ.get('SCRIPT_NAME', '')}{self._prefix}".rstrip("/")
+                        )
+                        stripped = path[len(self._prefix) :]
+                        environ["PATH_INFO"] = stripped or "/"
                 return self._app(environ, start_response)
 
-        self.app.wsgi_app = _QbitrrPrefixMiddleware(self.app.wsgi_app)
+        self.app.wsgi_app = _UrlBaseMiddleware(self.app.wsgi_app, configured_url_base())
 
         # Add cache control and security headers
         @self.app.after_request
@@ -382,13 +403,17 @@ class WebUI:
         # Flask session config (HttpOnly signed cookies for web login)
         # Keep session signing separate from bearer token auth.
         self.app.secret_key = secrets.token_hex(32)
-        self.app.config.update(
-            SESSION_COOKIE_NAME="qbitrr_session",
-            SESSION_COOKIE_HTTPONLY=True,
-            SESSION_COOKIE_SAMESITE="Lax",
-            SESSION_COOKIE_SECURE=bool(CONFIG.get("WebUI.BehindHttpsProxy", fallback=False)),
-            PERMANENT_SESSION_LIFETIME=timedelta(days=7),
-        )
+        session_config: dict[str, Any] = {
+            "SESSION_COOKIE_NAME": "qbitrr_session",
+            "SESSION_COOKIE_HTTPONLY": True,
+            "SESSION_COOKIE_SAMESITE": "Lax",
+            "SESSION_COOKIE_SECURE": bool(CONFIG.get("WebUI.BehindHttpsProxy", fallback=False)),
+            "PERMANENT_SESSION_LIFETIME": timedelta(days=7),
+        }
+        url_base = configured_url_base()
+        if url_base:
+            session_config["SESSION_COOKIE_PATH"] = f"{url_base}/"
+        self.app.config.update(session_config)
 
         # OIDC via Authlib
         self._oauth = OAuth(self.app)
@@ -2025,10 +2050,15 @@ class WebUI:
         def health():
             return jsonify({"status": "ok"})
 
+        def _public_url(path: str) -> str:
+            if not path.startswith("/"):
+                path = f"/{path}"
+            prefix = request.script_root.rstrip("/") or configured_url_base()
+            return f"{prefix}{path}" if prefix else path
+
         @app.get("/")
         def index():
-            prefix = request.script_root.rstrip("/")
-            return redirect(f"{prefix}/ui" if prefix else "/ui")
+            return redirect(_public_url("/ui"))
 
         def _get_supplied_token() -> str | None:
             _webui_logger = logging.getLogger("qBitrr.WebUI")
@@ -2110,9 +2140,7 @@ class WebUI:
             # Add cache-busting parameter based on config reload timestamp
             from flask import make_response
 
-            prefix = request.script_root.rstrip("/")
-            target = f"{prefix}/static/index.html" if prefix else "/static/index.html"
-            response = make_response(redirect(target))
+            response = make_response(redirect(_public_url("/static/index.html")))
             # Prevent caching of the UI entry point
             response.headers["Cache-Control"] = "no-cache, no-store, must-revalidate"
             response.headers["Pragma"] = "no-cache"
@@ -2137,8 +2165,7 @@ class WebUI:
 
         @app.get("/login")
         def login_page():
-            prefix = request.script_root.rstrip("/")
-            return redirect(f"{prefix}/ui" if prefix else "/ui")
+            return redirect(_public_url("/ui"))
 
         @app.post("/web/login")
         def web_login():
@@ -2230,13 +2257,14 @@ class WebUI:
         def web_oidc_challenge():
             if not _oidc_enabled():
                 return jsonify({"error": "OIDC not configured"}), 400
-            redirect_uri = request.host_url.rstrip("/") + oidc_callback_path
+            url_base = configured_url_base()
+            redirect_uri = request.host_url.rstrip("/") + url_base + oidc_callback_path
             return self._oauth.oidc.authorize_redirect(redirect_uri)
 
         @app.get(oidc_callback_path)
         def web_oidc_callback():
             if not _oidc_enabled():
-                return redirect("/ui")
+                return redirect(_public_url("/ui"))
             try:
                 token = self._oauth.oidc.authorize_access_token()
                 userinfo = token.get("userinfo") or self._oauth.oidc.userinfo()
@@ -2249,8 +2277,8 @@ class WebUI:
                 self.logger.info("User %s logged in via OIDC", username)
             except Exception:
                 self.logger.warning("OIDC callback failed", exc_info=True)
-                return redirect("/ui?auth_error=1")
-            return redirect("/ui")
+                return redirect(_public_url("/ui?auth_error=1"))
+            return redirect(_public_url("/ui"))
 
         def _processes_payload() -> dict[str, Any]:
             procs = []
@@ -3332,6 +3360,7 @@ class WebUI:
             stored_hash = (CONFIG.get("WebUI.PasswordHash", fallback="") or "").strip()
             setup_required = auth_required and not stored_hash and not oidc_enabled
             result["setup_required"] = setup_required
+            result["url_base"] = configured_url_base()
             return jsonify(result)
 
         def _handle_update():
@@ -3662,6 +3691,7 @@ class WebUI:
                 "WebUI.Host",
                 "WebUI.Port",
                 "WebUI.Token",
+                "WebUI.UrlBase",
                 "WebUI.AuthDisabled",
                 "WebUI.BehindHttpsProxy",
                 "WebUI.LocalAuthEnabled",
@@ -3709,6 +3739,8 @@ class WebUI:
                 # Never overwrite a real secret with the redaction placeholder from the client
                 if _is_sensitive_dotted_key(key) and str(val).strip() == REDACTED_PLACEHOLDER:
                     continue
+                if key == "WebUI.UrlBase":
+                    val = normalize_url_base(str(val) if val is not None else "")
                 _toml_set(CONFIG.config, key, val)
                 if key == "WebUI.Token":
                     # Update in-memory token immediately

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,8 @@
 {
-  "name": "webui",
-  "version": "0.0.0",
   "lockfileVersion": 3,
-  "requires": true,
+  "name": "webui",
   "packages": {
     "": {
-      "name": "webui",
-      "version": "0.0.0",
       "dependencies": {
         "@mantine/core": "^9.2.1",
         "@mantine/dates": "^9.2.1",
@@ -46,22 +42,22 @@
       "engines": {
         "node": ">=20.0.0",
         "npm": ">=9.0.0"
-      }
+      },
+      "name": "webui",
+      "version": "0.0.0"
     },
     "node_modules/@alloc/quick-lru": {
-      "version": "5.2.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "5.2.0"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -69,20 +65,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -100,17 +95,18 @@
         "json5": "^2.2.3",
         "semver": "^6.3.1"
       },
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -120,12 +116,11 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.1"
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
@@ -133,101 +128,102 @@
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.6"
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.0"
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
         "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.6"
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
         "@babel/traverse": "^7.28.6"
       },
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
+      },
+      "version": "7.28.6"
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.27.1"
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.5"
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.27.1"
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
         "@babel/types": "^7.28.6"
       },
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.6"
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
       "engines": {
         "node": ">=6.0.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.6"
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -235,11 +231,11 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.6"
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -251,56 +247,56 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "version": "1.10.0"
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "version": "1.10.0"
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "version": "1.2.1"
     },
     "node_modules/@emotion/babel-plugin": {
-      "version": "11.13.5",
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -313,34 +309,34 @@
         "find-root": "^1.1.0",
         "source-map": "^0.5.7",
         "stylis": "4.2.0"
-      }
+      },
+      "license": "MIT",
+      "version": "11.13.5"
     },
     "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.9.0"
     },
     "node_modules/@emotion/cache": {
-      "version": "11.14.0",
-      "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
         "@emotion/utils": "^1.4.2",
         "@emotion/weak-memoize": "^0.4.0",
         "stylis": "4.2.0"
-      }
+      },
+      "license": "MIT",
+      "version": "11.14.0"
     },
     "node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.9.2"
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.9.0"
     },
     "node_modules/@emotion/react": {
-      "version": "11.14.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -351,6 +347,7 @@
         "@emotion/weak-memoize": "^0.4.0",
         "hoist-non-react-statics": "^3.3.1"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0"
       },
@@ -358,123 +355,123 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "11.14.0"
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.3.3",
-      "license": "MIT",
       "dependencies": {
         "@emotion/hash": "^0.9.2",
         "@emotion/memoize": "^0.9.0",
         "@emotion/unitless": "^0.10.0",
         "@emotion/utils": "^1.4.2",
         "csstype": "^3.0.2"
-      }
+      },
+      "license": "MIT",
+      "version": "1.3.3"
     },
     "node_modules/@emotion/sheet": {
-      "version": "1.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.4.0"
     },
     "node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.10.0"
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.2.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
+      },
+      "version": "1.2.0"
     },
     "node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.4.2"
     },
     "node_modules/@emotion/weak-memoize": {
-      "version": "0.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.4.0"
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
+      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       },
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-      }
+      },
+      "version": "4.9.1"
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "3.4.3"
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.2",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
+      },
+      "license": "MIT",
+      "version": "4.12.2"
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "0.23.5"
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "0.6.0"
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "1.2.1"
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
       },
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^10.0.0"
       },
@@ -482,154 +479,153 @@
         "eslint": {
           "optional": true
         }
-      }
+      },
+      "version": "10.0.1"
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "3.0.5"
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "0.7.1"
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
-      }
+      },
+      "license": "MIT",
+      "version": "1.7.5"
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
-      }
+      },
+      "license": "MIT",
+      "version": "1.7.6"
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.27.19",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.8",
         "@floating-ui/utils": "^0.2.11",
         "tabbable": "^6.0.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=17.0.0",
         "react-dom": ">=17.0.0"
-      }
+      },
+      "version": "0.27.19"
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
-      }
+      },
+      "version": "2.1.8"
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.2.11"
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "0.19.1"
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=18.18.0"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "0.16.7"
     },
     "node_modules/@humanwhocodes/module-importer": {
-      "version": "1.0.1",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "1.0.1"
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.3",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "0.4.3"
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      }
+      },
+      "license": "MIT",
+      "version": "0.3.13"
     },
     "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "2.3.5"
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.2"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.5.5"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
+      },
+      "license": "MIT",
+      "version": "0.3.31"
     },
     "node_modules/@mantine/core": {
-      "version": "9.2.2",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "clsx": "^2.1.1",
@@ -637,36 +633,36 @@
         "react-remove-scroll": "^2.7.2",
         "type-fest": "^5.6.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@mantine/hooks": "9.2.2",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
-      }
+      },
+      "version": "9.2.2"
     },
     "node_modules/@mantine/dates": {
-      "version": "9.2.2",
-      "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@mantine/core": "9.2.2",
         "@mantine/hooks": "9.2.2",
         "dayjs": ">=1.0.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
-      }
+      },
+      "version": "9.2.2"
     },
     "node_modules/@mantine/hooks": {
-      "version": "9.2.1",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.0"
-      }
+      },
+      "version": "9.2.1"
     },
     "node_modules/@melloware/react-logviewer": {
-      "version": "6.5.2",
-      "license": "MPL-2.0",
       "dependencies": {
         "hotkeys-js": "4.0.3",
         "immutable": "5.1.5",
@@ -674,302 +670,301 @@
         "react-string-replace": "2.0.1",
         "virtua": "0.49.0"
       },
+      "license": "MPL-2.0",
       "peerDependencies": {
         "react": ">=17.0.0",
         "react-dom": ">=17.0.0"
-      }
+      },
+      "version": "6.5.2"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.1"
       },
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "license": "MIT",
+      "optional": true,
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "version": "1.1.4"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.132.0",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
+      },
+      "license": "MIT",
+      "version": "0.132.0"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
-      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
-      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
-      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
-      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
-      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
-      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
-      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
-      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
-      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.2",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
-      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
-      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
-      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
         "@napi-rs/wasm-runtime": "^1.1.4"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
+      },
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "license": "MIT",
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
-      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
-      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "version": "1.0.2"
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@tailwindcss/node": {
-      "version": "4.3.0",
       "dev": true,
       "license": "MIT",
+      "version": "1.0.1"
+    },
+    "node_modules/@tailwindcss/node": {
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "enhanced-resolve": "^5.21.0",
@@ -978,15 +973,17 @@
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
         "tailwindcss": "4.3.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.0",
+      },
       "dev": true,
       "license": "MIT",
+      "version": "4.3.0"
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "dev": true,
       "engines": {
         "node": ">= 20"
       },
+      "license": "MIT",
       "optionalDependencies": {
         "@tailwindcss/oxide-android-arm64": "4.3.0",
         "@tailwindcss/oxide-darwin-arm64": "4.3.0",
@@ -1000,163 +997,161 @@
         "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
         "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
         "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
-      }
+      },
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
-      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
-      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
-      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
-      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
-      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
-      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.0",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
-      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1168,9 +1163,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@emnapi/core": "^1.10.0",
         "@emnapi/runtime": "^1.10.0",
@@ -1179,59 +1171,63 @@
         "@tybys/wasm-util": "^0.10.1",
         "tslib": "^2.8.1"
       },
+      "dev": true,
       "engines": {
         "node": ">=14.0.0"
-      }
+      },
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
+      "license": "MIT",
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.3.0",
         "@tailwindcss/oxide": "4.3.0",
         "postcss": "^8.5.10",
         "tailwindcss": "4.3.0"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "4.3.0"
     },
     "node_modules/@tanstack/react-table": {
-      "version": "8.21.3",
-      "license": "MIT",
       "dependencies": {
         "@tanstack/table-core": "8.21.3"
       },
@@ -1242,153 +1238,150 @@
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
+      },
+      "version": "8.21.3"
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.21.3",
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
-      }
+      },
+      "license": "MIT",
+      "version": "8.21.3"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "license": "MIT",
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "version": "0.10.2"
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
-      }
+      },
+      "license": "MIT",
+      "version": "4.1.12"
     },
     "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.3.1"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.0.8"
     },
     "node_modules/@types/estree-jsx": {
-      "version": "1.0.5",
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.5"
     },
     "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.4"
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.15",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "7.0.15"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.23",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.17.23"
     },
     "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "4.17.12"
     },
     "node_modules/@types/mdast": {
-      "version": "4.0.4",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.4"
     },
     "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.1.0"
     },
     "node_modules/@types/node": {
-      "version": "25.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
-      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.1.tgz",
+      "version": "25.9.1"
     },
     "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.0.2"
     },
     "node_modules/@types/prismjs": {
-      "version": "1.26.6",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.26.6"
     },
     "node_modules/@types/react": {
-      "version": "19.2.16",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
-      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+      "version": "19.2.16"
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
+      },
+      "version": "19.2.3"
     },
     "node_modules/@types/react-syntax-highlighter": {
-      "version": "15.5.13",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "15.5.13"
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.12",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
-      }
+      },
+      "version": "4.4.12"
     },
     "node_modules/@types/unist": {
-      "version": "3.0.3",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "3.0.3"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
-      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.60.1",
@@ -1399,6 +1392,7 @@
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1406,28 +1400,27 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-JQ4S5GB0tfjO8BuJ4fcX+HodkzJjYBV+7OJ+wLygaX7OGQ7FudyHL4NSCA6ob+w3Yn+5MkKIozOwQhXeM7opVg==",
+      "license": "MIT",
       "peerDependencies": {
         "@typescript-eslint/parser": "^8.60.1",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.60.1.tgz",
+      "version": "8.60.1"
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
+      },
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "version": "7.0.5"
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
-      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
@@ -1435,6 +1428,7 @@
         "@typescript-eslint/visitor-keys": "8.60.1",
         "debug": "^4.4.3"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1442,22 +1436,22 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-A0M6ua6H252bVjPvvtSgl2QA4+ET9S5Mtkb2GDyTxIhH/C4qDItT7RQNO5PhMC6NXGYXOR9dIalcDDgBKT7oFA==",
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.60.1.tgz",
+      "version": "8.60.1"
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
-      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.60.1",
         "@typescript-eslint/types": "^8.60.1",
         "debug": "^4.4.3"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1465,34 +1459,34 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-eXkTH2bxmXlqD1RnOPmLZ9ZM9D3VwSx04JOwBnP9RQ+yUA5a2Mu7SfW8uaV2Aon53NJzZlZYuX7tn91Izf+xaw==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.60.1.tgz",
+      "version": "8.60.1"
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
-      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.60.1",
         "@typescript-eslint/visitor-keys": "8.60.1"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
+      },
+      "integrity": "sha512-gvI5OQoptnxQnchOirukCuQ55svJSTuD/4k5+pC267xyBtYry748R9/c3tYUzb/iE6RZfllRz2lVulLCHkTm4w==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.60.1.tgz",
+      "version": "8.60.1"
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
-      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1500,16 +1494,15 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-nh8w4qAteiKuZu3pSSzG/yGKpw0OlkrKnzFmbVRenKaD4qc+7i1GrmZaLVkr8rk4uipiPGMOW4YsM6WmKZ5CvA==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.60.1.tgz",
+      "version": "8.60.1"
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
-      "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.60.1",
         "@typescript-eslint/typescript-estree": "8.60.1",
@@ -1517,6 +1510,7 @@
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1524,31 +1518,30 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-sdwTrpjosW7ANQYJ39ZBF1ZyEMEGVB2UsikrserVM/30a/F1dTLnu9bGxEdosugyu5caigjLrR2qiD11asjI1A==",
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.60.1.tgz",
+      "version": "8.60.1"
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
-      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
+      },
+      "integrity": "sha512-4h0tY8ppCkdCzcrl2YM5M3my0xsE1Tf8om3owEu5oPWmXwkKRmk0j0LGDzYBGUcAlesEbxBhazqu/K4cu3Ug7w==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.60.1.tgz",
+      "version": "8.60.1"
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
-      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.60.1",
         "@typescript-eslint/tsconfig-utils": "8.60.1",
@@ -1560,6 +1553,7 @@
         "tinyglobby": "^0.2.15",
         "ts-api-utils": "^2.5.0"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1567,35 +1561,35 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-alpRkfG8hlVE5kdJW2GkfgDgXxold3e8e4l6EnmhRmRLbekgAPCCGDVD++sABy9FcgPFroq+uFcCSM1vR57Cew==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.60.1.tgz",
+      "version": "8.60.1"
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
-      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
-      "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
+      "dev": true,
       "engines": {
         "node": ">=10"
-      }
+      },
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
+      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "version": "7.8.1"
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
-      "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.60.1",
         "@typescript-eslint/types": "8.60.1",
         "@typescript-eslint/typescript-estree": "8.60.1"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1603,43 +1597,46 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-h2MPBLoNtjc3qZWfY3Tl51yPorQ2McHn8pJfcMNTcIvrrZrr90Ykffit0yjrPFWQcRcUxzH20+6OcVdW4yHtUg==",
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.60.1.tgz",
+      "version": "8.60.1"
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
-      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.60.1",
         "eslint-visitor-keys": "^5.0.0"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
+      },
+      "integrity": "sha512-EbGRQg4FhrmwLodl+t3JNAnXHWVr9Vp+Zl1QBZVPY4ByfkzIT8cX3K6QWODHtkIZqqJVEWvhHSx3v5PDHsaQag==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.60.1.tgz",
+      "version": "8.60.1"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "license": "ISC"
+      "license": "ISC",
+      "version": "1.3.0"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@rolldown/pluginutils": "^1.0.0"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
         "babel-plugin-react-compiler": "^1.0.0",
@@ -1652,45 +1649,58 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
-      }
+      },
+      "version": "6.0.2"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
-      }
+      },
+      "license": "MIT",
+      "version": "8.16.0"
     },
     "node_modules/acorn-jsx": {
-      "version": "5.3.2",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
+      },
+      "version": "5.3.2"
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       },
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
+      },
+      "license": "MIT",
+      "version": "6.14.0"
     },
     "node_modules/autoprefixer": {
-      "version": "10.5.0",
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
       "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
       "funding": [
         {
           "type": "opencollective",
@@ -1706,26 +1716,12 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.28.2",
-        "caniuse-lite": "^1.0.30001787",
-        "fraction.js": "^5.3.4",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
+      },
+      "version": "10.5.0"
     },
     "node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -1734,49 +1730,63 @@
       "engines": {
         "node": ">=10",
         "npm": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.0"
     },
     "node_modules/bail": {
-      "version": "2.0.2",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/balanced-match": {
-      "version": "4.0.4",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.4"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.20",
-      "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "2.10.20"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
+      "dev": true,
       "engines": {
         "node": "18 || 20 || >=22"
-      }
+      },
+      "license": "MIT",
+      "version": "5.0.5"
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
       "dev": true,
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
       "funding": [
         {
           "type": "opencollective",
@@ -1792,29 +1802,16 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
+      "version": "4.28.2"
     },
     "node_modules/callsites": {
-      "version": "3.1.0",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.0"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
       "dev": true,
       "funding": [
         {
@@ -1830,71 +1827,70 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "version": "1.0.30001788"
     },
     "node_modules/ccount": {
-      "version": "2.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/character-entities": {
-      "version": "2.0.2",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/character-entities-html4": {
-      "version": "2.1.0",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.1.0"
     },
     "node_modules/character-entities-legacy": {
-      "version": "3.0.0",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.0"
     },
     "node_modules/character-reference-invalid": {
-      "version": "2.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/clsx": {
-      "version": "2.1.1",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "2.1.1"
     },
     "node_modules/comma-separated-tokens": {
-      "version": "2.0.3",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.3"
     },
     "node_modules/convert-source-map": {
-      "version": "2.0.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.0"
     },
     "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -1904,140 +1900,142 @@
       },
       "engines": {
         "node": ">=10"
-      }
+      },
+      "license": "MIT",
+      "version": "7.1.0"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       },
+      "dev": true,
       "engines": {
         "node": ">= 8"
-      }
+      },
+      "license": "MIT",
+      "version": "7.0.6"
     },
     "node_modules/csstype": {
-      "version": "3.2.3",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "3.2.3"
     },
     "node_modules/debug": {
-      "version": "4.4.3",
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
       },
+      "license": "MIT",
       "peerDependenciesMeta": {
         "supports-color": {
           "optional": true
         }
-      }
+      },
+      "version": "4.4.3"
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.3.0",
-      "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "1.3.0"
     },
     "node_modules/deep-is": {
-      "version": "0.1.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.1.4"
     },
     "node_modules/dequal": {
-      "version": "2.0.3",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.3"
     },
     "node_modules/detect-libc": {
-      "version": "2.1.2",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "2.1.2"
     },
     "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.1.0"
     },
     "node_modules/devlop": {
-      "version": "1.1.0",
-      "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "1.1.0"
     },
     "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
-      }
+      },
+      "license": "MIT",
+      "version": "5.2.1"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.340",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "version": "1.5.340"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.3",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.3"
       },
+      "dev": true,
       "engines": {
         "node": ">=10.13.0"
-      }
+      },
+      "license": "MIT",
+      "version": "5.21.3"
     },
     "node_modules/error-ex": {
-      "version": "1.3.4",
-      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
+      },
+      "license": "MIT",
+      "version": "1.3.4"
     },
     "node_modules/escalade": {
-      "version": "3.2.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "3.2.0"
     },
     "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/eslint": {
-      "version": "10.4.0",
-      "dev": true,
-      "license": "MIT",
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2070,15 +2068,14 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
       },
+      "license": "MIT",
       "peerDependencies": {
         "jiti": "*"
       },
@@ -2086,12 +2083,10 @@
         "jiti": {
           "optional": true
         }
-      }
+      },
+      "version": "10.4.0"
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/parser": "^7.24.4",
@@ -2099,147 +2094,149 @@
         "zod": "^3.25.0 || ^4.0.0",
         "zod-validation-error": "^3.5.0 || ^4.0.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=18"
       },
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
-      }
+      },
+      "version": "7.1.1"
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.5.2",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "eslint": "^9 || ^10"
-      }
+      },
+      "version": "0.5.2"
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "@types/esrecurse": "^4.3.1",
         "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
+      },
+      "license": "BSD-2-Clause",
+      "version": "9.1.2"
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "5.0.1"
     },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^5.0.1"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
+      },
+      "license": "BSD-2-Clause",
+      "version": "11.2.0"
     },
     "node_modules/esquery": {
-      "version": "1.7.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=0.10"
-      }
+      },
+      "license": "BSD-3-Clause",
+      "version": "1.7.0"
     },
     "node_modules/esrecurse": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=4.0"
-      }
+      },
+      "license": "BSD-2-Clause",
+      "version": "4.3.0"
     },
     "node_modules/estraverse": {
-      "version": "5.3.0",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
-      }
+      },
+      "license": "BSD-2-Clause",
+      "version": "5.3.0"
     },
     "node_modules/estree-util-is-identifier-name": {
-      "version": "3.0.0",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.0"
     },
     "node_modules/esutils": {
-      "version": "2.0.3",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "BSD-2-Clause",
+      "version": "2.0.3"
     },
     "node_modules/extend": {
-      "version": "3.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "3.0.2"
     },
     "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "3.1.3"
     },
     "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.1.0"
     },
     "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.6"
     },
     "node_modules/fault": {
-      "version": "1.0.4",
-      "license": "MIT",
       "dependencies": {
         "format": "^0.2.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.4"
     },
     "node_modules/fdir": {
-      "version": "6.5.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -2247,161 +2244,160 @@
         "picomatch": {
           "optional": true
         }
-      }
+      },
+      "version": "6.5.0"
     },
     "node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=16.0.0"
-      }
+      },
+      "license": "MIT",
+      "version": "8.0.0"
     },
     "node_modules/find-root": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.1.0"
     },
     "node_modules/find-up": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "5.0.0"
     },
     "node_modules/flat-cache": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
       },
+      "dev": true,
       "engines": {
         "node": ">=16"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.1"
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "version": "3.4.2"
     },
     "node_modules/format": {
-      "version": "0.2.2",
       "engines": {
         "node": ">=0.4.x"
-      }
+      },
+      "version": "0.2.2"
     },
     "node_modules/fraction.js": {
-      "version": "5.3.4",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
-      }
+      },
+      "license": "MIT",
+      "version": "5.3.4"
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      },
       "hasInstallScript": true,
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "version": "2.3.3"
     },
     "node_modules/function-bind": {
-      "version": "1.1.2",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "license": "MIT",
+      "version": "1.1.2"
     },
     "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.0-beta.2"
     },
     "node_modules/get-nonce": {
-      "version": "1.0.1",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.1"
     },
     "node_modules/glob-parent": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
+      "dev": true,
       "engines": {
         "node": ">=10.13.0"
-      }
+      },
+      "license": "ISC",
+      "version": "6.0.2"
     },
     "node_modules/globals": {
-      "version": "17.6.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "17.6.0"
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.11",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "version": "4.2.11"
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/hast-util-to-jsx-runtime": {
-      "version": "2.3.6",
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -2422,22 +2418,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "2.3.6"
     },
     "node_modules/hast-util-whitespace": {
-      "version": "3.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.0"
     },
     "node_modules/hastscript": {
-      "version": "9.0.1",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -2448,77 +2444,77 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "9.0.1"
     },
     "node_modules/hermes-estree": {
-      "version": "0.25.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.25.1"
     },
     "node_modules/hermes-parser": {
-      "version": "0.25.1",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "0.25.1"
     },
     "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
-      }
+      },
+      "license": "BSD-3-Clause",
+      "version": "10.7.3"
     },
     "node_modules/highlightjs-vue": {
-      "version": "1.0.0",
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "version": "1.0.0"
     },
     "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
-      }
+      },
+      "license": "BSD-3-Clause",
+      "version": "3.3.2"
     },
     "node_modules/hotkeys-js": {
-      "version": "4.0.3",
-      "license": "MIT",
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.3"
     },
     "node_modules/html-url-attributes": {
-      "version": "3.0.1",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.1"
     },
     "node_modules/ignore": {
-      "version": "5.3.2",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
+      },
+      "license": "MIT",
+      "version": "5.3.2"
     },
     "node_modules/immer": {
-      "version": "11.1.8",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
-      }
+      },
+      "license": "MIT",
+      "version": "11.1.8"
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "5.1.5"
     },
     "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2528,31 +2524,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "3.3.1"
     },
     "node_modules/imurmurhash": {
-      "version": "0.1.4",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
-      }
+      },
+      "license": "MIT",
+      "version": "0.1.4"
     },
     "node_modules/inline-style-parser": {
-      "version": "0.2.7",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.2.7"
     },
     "node_modules/is-alphabetical": {
-      "version": "2.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/is-alphanumerical": {
-      "version": "2.0.1",
-      "license": "MIT",
       "dependencies": {
         "is-alphabetical": "^2.0.0",
         "is-decimal": "^2.0.0"
@@ -2560,15 +2556,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.2.1"
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -2577,137 +2573,137 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "license": "MIT",
+      "version": "2.16.1"
     },
     "node_modules/is-decimal": {
-      "version": "2.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/is-extglob": {
-      "version": "2.1.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "MIT",
+      "version": "2.1.1"
     },
     "node_modules/is-glob": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.3"
     },
     "node_modules/is-hexadecimal": {
-      "version": "2.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "4.1.0"
     },
     "node_modules/isexe": {
-      "version": "2.0.0",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "version": "2.0.0"
     },
     "node_modules/jiti": {
-      "version": "2.7.0",
-      "dev": true,
-      "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "2.7.0"
     },
     "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/jsesc": {
-      "version": "3.1.0",
-      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.0"
     },
     "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "license": "MIT"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
       "dev": true,
       "license": "MIT",
+      "version": "3.0.1"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "license": "MIT",
+      "version": "2.3.1"
+    },
+    "node_modules/json-schema-traverse": {
+      "dev": true,
+      "license": "MIT",
+      "version": "0.4.1"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "dev": true,
+      "license": "MIT",
+      "version": "1.0.1"
+    },
+    "node_modules/json5": {
       "bin": {
         "json5": "lib/cli.js"
       },
+      "dev": true,
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "2.2.3"
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/levn": {
-      "version": "0.4.1",
+      },
       "dev": true,
       "license": "MIT",
+      "version": "4.5.4"
+    },
+    "node_modules/levn": {
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       },
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
+      },
+      "license": "MIT",
+      "version": "0.4.1"
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "dev": true,
-      "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
+      "dev": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2715,6 +2711,7 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
+      "license": "MPL-2.0",
       "optionalDependencies": {
         "lightningcss-android-arm64": "1.32.0",
         "lightningcss-darwin-arm64": "1.32.0",
@@ -2727,280 +2724,279 @@
         "lightningcss-linux-x64-musl": "1.32.0",
         "lightningcss-win32-arm64-msvc": "1.32.0",
         "lightningcss-win32-x64-msvc": "1.32.0"
-      }
+      },
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
       ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
-      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.2.4"
     },
     "node_modules/locate-path": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "6.0.0"
     },
     "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.18.1"
     },
     "node_modules/longest-streak": {
-      "version": "3.1.0",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.0"
     },
     "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "license": "MIT",
+      "bin": {
+        "loose-envify": "cli.js"
+      },
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
+      "license": "MIT",
+      "version": "1.4.0"
     },
     "node_modules/lowlight": {
-      "version": "1.20.0",
-      "license": "MIT",
       "dependencies": {
         "fault": "^1.0.0",
         "highlight.js": "~10.7.0"
@@ -3008,27 +3004,27 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "1.20.0"
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
+      },
+      "dev": true,
+      "license": "ISC",
+      "version": "5.1.1"
     },
     "node_modules/magic-string": {
-      "version": "0.30.21",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "0.30.21"
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -3046,11 +3042,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/mdast-util-mdx-expression": {
-      "version": "2.0.1",
-      "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -3062,11 +3058,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/mdast-util-mdx-jsx": {
-      "version": "3.2.0",
-      "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -3084,11 +3080,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "3.2.0"
     },
     "node_modules/mdast-util-mdxjs-esm": {
-      "version": "2.0.1",
-      "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -3100,11 +3096,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/mdast-util-phrasing": {
-      "version": "4.1.0",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "unist-util-is": "^6.0.0"
@@ -3112,11 +3108,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "4.1.0"
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.1",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -3131,11 +3127,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "13.2.1"
     },
     "node_modules/mdast-util-to-markdown": {
-      "version": "2.1.2",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -3150,36 +3146,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "2.1.2"
     },
     "node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/memoize-one": {
-      "version": "6.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "6.0.0"
     },
     "node_modules/micromark": {
-      "version": "4.0.2",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -3198,10 +3184,7 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-core-commonmark": {
-      "version": "2.0.3",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3213,6 +3196,9 @@
         }
       ],
       "license": "MIT",
+      "version": "4.0.2"
+    },
+    "node_modules/micromark-core-commonmark": {
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "devlop": "^1.0.0",
@@ -3230,10 +3216,7 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-destination": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3245,14 +3228,14 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.3"
+    },
+    "node_modules/micromark-factory-destination": {
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-label": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3264,15 +3247,33 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-factory-label": {
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-factory-space": {
-      "version": "2.0.1",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3284,13 +3285,15 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
+      "version": "2.0.1"
     },
     "node_modules/micromark-factory-title": {
-      "version": "2.0.1",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3302,35 +3305,15 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
+      "version": "2.0.1"
     },
     "node_modules/micromark-factory-whitespace": {
-      "version": "2.0.1",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-character": {
-      "version": "2.1.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3342,30 +3325,30 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-util-character": {
       "dependencies": {
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.1.1"
     },
     "node_modules/micromark-util-chunked": {
-      "version": "2.0.1",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-classify-character": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3377,14 +3360,14 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-util-classify-character": {
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-combine-extensions": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3396,30 +3379,30 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-util-combine-extensions": {
       "dependencies": {
         "micromark-util-chunked": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-decode-numeric-character-reference": {
-      "version": "2.0.2",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-string": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3431,15 +3414,29 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.2"
+    },
+    "node_modules/micromark-util-decode-string": {
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-decode-numeric-character-reference": "^2.0.0",
         "micromark-util-symbol": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-encode": {
-      "version": "2.0.1",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3450,10 +3447,10 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-html-tag-name": {
-      "version": "2.0.1",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3464,44 +3461,30 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-normalize-identifier": {
-      "version": "2.0.1",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-resolve-all": {
-      "version": "2.0.1",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3513,14 +3496,14 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-encode": "^2.0.0",
         "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-subtokenize": {
-      "version": "2.1.0",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3532,15 +3515,29 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-util-subtokenize": {
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-chunked": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.1.0"
     },
     "node_modules/micromark-util-symbol": {
-      "version": "2.0.1",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3551,10 +3548,10 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-types": {
-      "version": "2.0.2",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3565,33 +3562,39 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
+      "dev": true,
       "engines": {
         "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
+      },
+      "license": "BlueOak-1.0.0",
+      "version": "10.2.4"
     },
     "node_modules/mitt": {
-      "version": "3.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "3.0.1"
     },
     "node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.1.3"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
       "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      },
       "funding": [
         {
           "type": "github",
@@ -3599,34 +3602,26 @@
         }
       ],
       "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
+      "version": "3.3.12"
     },
     "node_modules/natural-compare": {
-      "version": "1.4.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.4.0"
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.37"
     },
     "node_modules/object-assign": {
-      "version": "4.1.1",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "MIT",
+      "version": "4.1.1"
     },
     "node_modules/optionator": {
-      "version": "0.9.4",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -3635,51 +3630,52 @@
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.5"
       },
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
+      },
+      "license": "MIT",
+      "version": "0.9.4"
     },
     "node_modules/p-limit": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.0"
     },
     "node_modules/p-locate": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "5.0.0"
     },
     "node_modules/parent-module": {
-      "version": "1.0.1",
-      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.1"
     },
     "node_modules/parse-entities": {
-      "version": "4.0.2",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "character-entities-legacy": "^3.0.0",
@@ -3692,15 +3688,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.2"
     },
     "node_modules/parse-entities/node_modules/@types/unist": {
-      "version": "2.0.11",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.11"
     },
     "node_modules/parse-json": {
-      "version": "5.2.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -3712,53 +3708,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "5.2.0"
     },
     "node_modules/path-exists": {
-      "version": "4.0.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/path-key": {
-      "version": "3.1.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.1"
     },
     "node_modules/path-parse": {
-      "version": "1.0.7",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.0.7"
     },
     "node_modules/path-type": {
-      "version": "4.0.0",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/picocolors": {
-      "version": "1.1.1",
-      "license": "ISC"
+      "license": "ISC",
+      "version": "1.1.1"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.4"
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
       "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
       "funding": [
         {
           "type": "opencollective",
@@ -3774,84 +3779,75 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
+      "version": "8.5.15"
     },
     "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.2.0"
     },
     "node_modules/prelude-ls": {
-      "version": "1.2.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
+      },
+      "license": "MIT",
+      "version": "1.2.1"
     },
     "node_modules/prismjs": {
-      "version": "1.30.0",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "1.30.0"
     },
     "node_modules/prop-types": {
-      "version": "15.8.1",
-      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
-      }
+      },
+      "license": "MIT",
+      "version": "15.8.1"
     },
     "node_modules/property-information": {
-      "version": "7.1.0",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "7.1.0"
     },
     "node_modules/punycode": {
-      "version": "2.3.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "2.3.1"
     },
     "node_modules/react": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
-      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "version": "19.2.7"
     },
     "node_modules/react-dom": {
-      "version": "19.2.7",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
-      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
-      "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.7"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "version": "19.2.7"
     },
     "node_modules/react-hook-form": {
-      "version": "7.76.0",
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3859,17 +3855,17 @@
         "type": "opencollective",
         "url": "https://opencollective.com/react-hook-form"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
-      }
+      },
+      "version": "7.76.0"
     },
     "node_modules/react-is": {
-      "version": "16.13.1",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "16.13.1"
     },
     "node_modules/react-markdown": {
-      "version": "10.1.0",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -3887,22 +3883,22 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
-      }
+      },
+      "version": "10.1.0"
     },
     "node_modules/react-number-format": {
-      "version": "5.4.5",
       "license": "MIT",
       "peerDependencies": {
         "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
+      },
+      "version": "5.4.5"
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.7.2",
-      "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
         "react-style-singleton": "^2.2.3",
@@ -3913,6 +3909,7 @@
       "engines": {
         "node": ">=10"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
@@ -3921,11 +3918,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "2.7.2"
     },
     "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.8",
-      "license": "MIT",
       "dependencies": {
         "react-style-singleton": "^2.2.2",
         "tslib": "^2.0.0"
@@ -3933,6 +3929,7 @@
       "engines": {
         "node": ">=10"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -3941,11 +3938,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "2.3.8"
     },
     "node_modules/react-select": {
-      "version": "5.10.2",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -3957,18 +3953,18 @@
         "react-transition-group": "^4.3.0",
         "use-isomorphic-layout-effect": "^1.2.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
+      },
+      "version": "5.10.2"
     },
     "node_modules/react-string-replace": {
-      "version": "2.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/react-style-singleton": {
-      "version": "2.2.3",
-      "license": "MIT",
       "dependencies": {
         "get-nonce": "^1.0.0",
         "tslib": "^2.0.0"
@@ -3976,6 +3972,7 @@
       "engines": {
         "node": ">=10"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
@@ -3984,11 +3981,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "2.2.3"
     },
     "node_modules/react-syntax-highlighter": {
-      "version": "16.1.1",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "highlight.js": "^10.4.1",
@@ -4000,27 +3996,27 @@
       "engines": {
         "node": ">= 16.20.2"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": ">= 0.14.0"
-      }
+      },
+      "version": "16.1.1"
     },
     "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       },
+      "license": "BSD-3-Clause",
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
+      },
+      "version": "4.4.5"
     },
     "node_modules/refractor": {
-      "version": "5.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/prismjs": "^1.0.0",
@@ -4030,11 +4026,11 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "5.0.0"
     },
     "node_modules/remark-parse": {
-      "version": "11.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -4044,11 +4040,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "11.0.0"
     },
     "node_modules/remark-rehype": {
-      "version": "11.1.2",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -4059,47 +4055,48 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "11.1.2"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "license": "MIT",
+      "bin": {
+        "resolve": "bin/resolve"
+      },
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "license": "MIT",
+      "version": "1.22.11"
     },
     "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/rolldown": {
-      "version": "1.0.2",
-      "dev": true,
-      "license": "MIT",
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
       "dependencies": {
         "@oxc-project/types": "=0.132.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
+      "license": "MIT",
       "optionalDependencies": {
         "@rolldown/binding-android-arm64": "1.0.2",
         "@rolldown/binding-darwin-arm64": "1.0.2",
@@ -4116,65 +4113,64 @@
         "@rolldown/binding-wasm32-wasi": "1.0.2",
         "@rolldown/binding-win32-arm64-msvc": "1.0.2",
         "@rolldown/binding-win32-x64-msvc": "1.0.2"
-      }
+      },
+      "version": "1.0.2"
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.27.0"
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
+      },
+      "dev": true,
+      "license": "ISC",
+      "version": "6.3.1"
     },
     "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.0"
     },
     "node_modules/shebang-regex": {
-      "version": "3.0.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.0"
     },
     "node_modules/source-map": {
-      "version": "0.5.7",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "BSD-3-Clause",
+      "version": "0.5.7"
     },
     "node_modules/source-map-js": {
-      "version": "1.2.1",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "BSD-3-Clause",
+      "version": "1.2.1"
     },
     "node_modules/space-separated-tokens": {
-      "version": "2.0.2",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/stringify-entities": {
-      "version": "4.0.4",
-      "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
         "character-entities-legacy": "^3.0.0"
@@ -4182,129 +4178,129 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.4"
     },
     "node_modules/style-to-js": {
-      "version": "1.1.21",
-      "license": "MIT",
       "dependencies": {
         "style-to-object": "1.0.14"
-      }
+      },
+      "license": "MIT",
+      "version": "1.1.21"
     },
     "node_modules/style-to-object": {
-      "version": "1.0.14",
-      "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.14"
     },
     "node_modules/stylis": {
-      "version": "4.2.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.2.0"
     },
     "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.0"
     },
     "node_modules/tabbable": {
-      "version": "6.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "6.4.0"
     },
     "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.0"
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/tapable": {
-      "version": "2.3.3",
       "dev": true,
       "license": "MIT",
+      "version": "4.3.0"
+    },
+    "node_modules/tapable": {
+      "dev": true,
       "engines": {
         "node": ">=6"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
+      },
+      "license": "MIT",
+      "version": "2.3.3"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
       },
+      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
+      },
+      "license": "MIT",
+      "version": "0.2.16"
     },
     "node_modules/trim-lines": {
-      "version": "3.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.1"
     },
     "node_modules/trough": {
-      "version": "2.2.0",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.2.0"
     },
     "node_modules/ts-api-utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
-      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.12"
       },
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "version": "2.5.0"
     },
     "node_modules/tslib": {
-      "version": "2.8.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "version": "2.8.1"
     },
     "node_modules/type-check": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
+      },
+      "license": "MIT",
+      "version": "0.4.0"
     },
     "node_modules/type-fest": {
-      "version": "5.6.0",
-      "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
       },
@@ -4313,32 +4309,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "(MIT OR CC0-1.0)",
+      "version": "5.6.0"
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
+      "dev": true,
       "engines": {
         "node": ">=14.17"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "6.0.3"
     },
     "node_modules/typescript-eslint": {
-      "version": "8.60.1",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
-      "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.60.1",
         "@typescript-eslint/parser": "8.60.1",
         "@typescript-eslint/typescript-estree": "8.60.1",
         "@typescript-eslint/utils": "8.60.1"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4346,19 +4340,21 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-6m5hkkRAp8lKvhVpcprAIn5KkehQEh+47oHH2VGnExEh7dhNxXlg6GPAOIu6TxbVQxhebrJDvjl3020ooiWCMA==",
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.60.1.tgz",
+      "version": "8.60.1"
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "7.24.6"
     },
     "node_modules/unified": {
-      "version": "11.0.5",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -4371,44 +4367,44 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "11.0.5"
     },
     "node_modules/unist-util-is": {
-      "version": "6.0.1",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "6.0.1"
     },
     "node_modules/unist-util-position": {
-      "version": "5.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "5.0.0"
     },
     "node_modules/unist-util-stringify-position": {
-      "version": "4.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",
@@ -4417,11 +4413,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "5.1.0"
     },
     "node_modules/unist-util-visit-parents": {
-      "version": "6.0.2",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0"
@@ -4429,10 +4425,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "6.0.2"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
       "dev": true,
       "funding": [
         {
@@ -4449,34 +4453,27 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
+      },
+      "version": "1.2.3"
     },
     "node_modules/uri-js": {
-      "version": "4.4.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
+      },
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "version": "4.4.1"
     },
     "node_modules/use-callback-ref": {
-      "version": "1.3.3",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
@@ -4485,10 +4482,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "1.3.3"
     },
     "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.2.1",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -4497,11 +4494,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "1.2.1"
     },
     "node_modules/use-sidecar": {
-      "version": "1.1.3",
-      "license": "MIT",
       "dependencies": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
@@ -4509,6 +4505,7 @@
       "engines": {
         "node": ">=10"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
@@ -4517,11 +4514,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "1.1.3"
     },
     "node_modules/vfile": {
-      "version": "6.0.3",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
@@ -4529,11 +4525,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "6.0.3"
     },
     "node_modules/vfile-message": {
-      "version": "4.0.3",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-stringify-position": "^4.0.0"
@@ -4541,10 +4537,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.3"
     },
     "node_modules/virtua": {
-      "version": "0.49.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.14.0",
@@ -4569,12 +4566,13 @@
         "vue": {
           "optional": true
         }
-      }
+      },
+      "version": "0.49.0"
     },
     "node_modules/vite": {
-      "version": "8.0.14",
-      "dev": true,
-      "license": "MIT",
+      "bin": {
+        "vite": "bin/vite.js"
+      },
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4582,15 +4580,14 @@
         "rolldown": "1.0.2",
         "tinyglobby": "^0.2.16"
       },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
       },
+      "license": "MIT",
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       },
@@ -4645,38 +4642,37 @@
         "yaml": {
           "optional": true
         }
-      }
+      },
+      "version": "8.0.14"
     },
     "node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
       "bin": {
         "node-which": "bin/node-which"
       },
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "dev": true,
       "engines": {
         "node": ">= 8"
-      }
+      },
+      "license": "ISC",
+      "version": "2.0.2"
     },
     "node_modules/word-wrap": {
-      "version": "1.2.5",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "MIT",
+      "version": "1.2.5"
     },
     "node_modules/yallist": {
-      "version": "3.1.1",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "version": "3.1.1"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -4685,45 +4681,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
+      },
+      "license": "ISC",
+      "version": "2.8.3"
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "0.1.0"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
+      },
+      "license": "MIT",
+      "version": "4.3.6"
     },
     "node_modules/zod-validation-error": {
-      "version": "4.0.2",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      }
+      },
+      "version": "4.0.2"
     },
     "node_modules/zwitch": {
-      "version": "2.0.4",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.4"
     }
-  }
+  },
+  "requires": true,
+  "version": "0.0.0"
 }

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -13,7 +13,7 @@
         "immer": "^11.1.8",
         "lodash-es": "^4.18.1",
         "react": "^19.2.6",
-        "react-dom": "^19.2.6",
+        "react-dom": "^19.2.7",
         "react-hook-form": "^7.76.0",
         "react-markdown": "^10.1.0",
         "react-select": "^5.10.2",
@@ -3851,11 +3851,13 @@
       "dependencies": {
         "scheduler": "^0.27.0"
       },
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       },
-      "version": "19.2.6"
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "version": "19.2.7"
     },
     "node_modules/react-hook-form": {
       "engines": {

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -1,12 +1,8 @@
 {
-  "name": "webui",
-  "version": "0.0.0",
   "lockfileVersion": 3,
-  "requires": true,
+  "name": "webui",
   "packages": {
     "": {
-      "name": "webui",
-      "version": "0.0.0",
       "dependencies": {
         "@mantine/core": "^9.2.1",
         "@mantine/dates": "^9.2.1",
@@ -46,22 +42,22 @@
       "engines": {
         "node": ">=20.0.0",
         "npm": ">=9.0.0"
-      }
+      },
+      "name": "webui",
+      "version": "0.0.0"
     },
     "node_modules/@alloc/quick-lru": {
-      "version": "5.2.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "5.2.0"
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.28.5",
         "js-tokens": "^4.0.0",
@@ -69,20 +65,19 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -100,17 +95,18 @@
         "json5": "^2.2.3",
         "semver": "^6.3.1"
       },
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/babel"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "license": "MIT",
       "dependencies": {
         "@babel/parser": "^7.29.0",
         "@babel/types": "^7.29.0",
@@ -120,12 +116,11 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.1"
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/compat-data": "^7.28.6",
         "@babel/helper-validator-option": "^7.27.1",
@@ -133,101 +128,102 @@
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
       },
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.6"
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.0"
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "license": "MIT",
       "dependencies": {
         "@babel/traverse": "^7.28.6",
         "@babel/types": "^7.28.6"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.6"
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.28.6",
         "@babel/helper-validator-identifier": "^7.28.5",
         "@babel/traverse": "^7.28.6"
       },
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@babel/core": "^7.0.0"
-      }
+      },
+      "version": "7.28.6"
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.27.1"
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.5"
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.27.1"
     },
     "node_modules/@babel/helpers": {
-      "version": "7.28.6",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/template": "^7.28.6",
         "@babel/types": "^7.28.6"
       },
+      "dev": true,
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.6"
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.0",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/types": "^7.29.0"
-      },
       "bin": {
         "parser": "bin/babel-parser.js"
       },
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
       "engines": {
         "node": ">=6.0.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@babel/runtime": {
-      "version": "7.28.6",
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.6"
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/parser": "^7.28.6",
@@ -235,11 +231,11 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.28.6"
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -251,56 +247,56 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",
         "@babel/helper-validator-identifier": "^7.28.5"
       },
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "7.29.0"
     },
     "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "license": "MIT",
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "version": "1.10.0"
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "license": "MIT",
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "version": "1.10.0"
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+      "license": "MIT",
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "version": "1.2.1"
     },
     "node_modules/@emotion/babel-plugin": {
-      "version": "11.13.5",
-      "license": "MIT",
       "dependencies": {
         "@babel/helper-module-imports": "^7.16.7",
         "@babel/runtime": "^7.18.3",
@@ -313,34 +309,34 @@
         "find-root": "^1.1.0",
         "source-map": "^0.5.7",
         "stylis": "4.2.0"
-      }
+      },
+      "license": "MIT",
+      "version": "11.13.5"
     },
     "node_modules/@emotion/babel-plugin/node_modules/convert-source-map": {
-      "version": "1.9.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.9.0"
     },
     "node_modules/@emotion/cache": {
-      "version": "11.14.0",
-      "license": "MIT",
       "dependencies": {
         "@emotion/memoize": "^0.9.0",
         "@emotion/sheet": "^1.4.0",
         "@emotion/utils": "^1.4.2",
         "@emotion/weak-memoize": "^0.4.0",
         "stylis": "4.2.0"
-      }
+      },
+      "license": "MIT",
+      "version": "11.14.0"
     },
     "node_modules/@emotion/hash": {
-      "version": "0.9.2",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.9.2"
     },
     "node_modules/@emotion/memoize": {
-      "version": "0.9.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.9.0"
     },
     "node_modules/@emotion/react": {
-      "version": "11.14.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -351,6 +347,7 @@
         "@emotion/weak-memoize": "^0.4.0",
         "hoist-non-react-statics": "^3.3.1"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0"
       },
@@ -358,125 +355,125 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "11.14.0"
     },
     "node_modules/@emotion/serialize": {
-      "version": "1.3.3",
-      "license": "MIT",
       "dependencies": {
         "@emotion/hash": "^0.9.2",
         "@emotion/memoize": "^0.9.0",
         "@emotion/unitless": "^0.10.0",
         "@emotion/utils": "^1.4.2",
         "csstype": "^3.0.2"
-      }
+      },
+      "license": "MIT",
+      "version": "1.3.3"
     },
     "node_modules/@emotion/sheet": {
-      "version": "1.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.4.0"
     },
     "node_modules/@emotion/unitless": {
-      "version": "0.10.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.10.0"
     },
     "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
-      "version": "1.2.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0"
-      }
+      },
+      "version": "1.2.0"
     },
     "node_modules/@emotion/utils": {
-      "version": "1.4.2",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.4.2"
     },
     "node_modules/@emotion/weak-memoize": {
-      "version": "0.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.4.0"
     },
     "node_modules/@eslint-community/eslint-utils": {
-      "version": "4.9.1",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "eslint-visitor-keys": "^3.4.3"
       },
+      "dev": true,
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       },
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
-      }
+      },
+      "version": "4.9.1"
     },
     "node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
-      "version": "3.4.3",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "3.4.3"
     },
     "node_modules/@eslint-community/regexpp": {
-      "version": "4.12.2",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
-      }
+      },
+      "license": "MIT",
+      "version": "4.12.2"
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.23.5",
-      "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
         "minimatch": "^10.2.4"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "0.23.5"
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
-      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
-      "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
+      },
+      "integrity": "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA==",
+      "license": "Apache-2.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.6.0.tgz",
+      "version": "0.6.0"
     },
     "node_modules/@eslint/core": {
-      "version": "1.2.1",
-      "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "1.2.1"
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
       },
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^10.0.0"
       },
@@ -484,156 +481,153 @@
         "eslint": {
           "optional": true
         }
-      }
+      },
+      "version": "10.0.1"
     },
     "node_modules/@eslint/object-schema": {
-      "version": "3.0.5",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "3.0.5"
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.7.1",
-      "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "0.7.1"
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.7.5",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/utils": "^0.2.11"
-      }
+      },
+      "license": "MIT",
+      "version": "1.7.5"
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.7.6",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
-      }
+      },
+      "license": "MIT",
+      "version": "1.7.6"
     },
     "node_modules/@floating-ui/react": {
-      "version": "0.27.19",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.1.8",
         "@floating-ui/utils": "^0.2.11",
         "tabbable": "^6.0.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=17.0.0",
         "react-dom": ">=17.0.0"
-      }
+      },
+      "version": "0.27.19"
     },
     "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.8",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.7.6"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
-      }
+      },
+      "version": "2.1.8"
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.11",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.2.11"
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "0.19.1"
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "dev": true,
-      "license": "Apache-2.0",
       "dependencies": {
         "@humanfs/core": "^0.19.1",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=18.18.0"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "0.16.7"
     },
     "node_modules/@humanwhocodes/module-importer": {
-      "version": "1.0.1",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=12.22"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "1.0.1"
     },
     "node_modules/@humanwhocodes/retry": {
-      "version": "0.4.3",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/nzakas"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "0.4.3"
     },
     "node_modules/@jridgewell/gen-mapping": {
-      "version": "0.3.13",
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0",
         "@jridgewell/trace-mapping": "^0.3.24"
-      }
+      },
+      "license": "MIT",
+      "version": "0.3.13"
     },
     "node_modules/@jridgewell/remapping": {
-      "version": "2.3.5",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/gen-mapping": "^0.3.5",
         "@jridgewell/trace-mapping": "^0.3.24"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "2.3.5"
     },
     "node_modules/@jridgewell/resolve-uri": {
-      "version": "3.1.2",
-      "license": "MIT",
       "engines": {
         "node": ">=6.0.0"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.2"
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.5.5",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.5.5"
     },
     "node_modules/@jridgewell/trace-mapping": {
-      "version": "0.3.31",
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
+      },
+      "license": "MIT",
+      "version": "0.3.31"
     },
     "node_modules/@mantine/core": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-9.2.1.tgz",
-      "integrity": "sha512-CicPg9i2dM2pGp1jj+dMiR/63OFDsPjgJke4v5+0nbfJ+C7gn4C+7ltrp4RIETDMZHcj0fFuDRG0qtbiyBxvWA==",
-      "license": "MIT",
       "dependencies": {
         "@floating-ui/react": "^0.27.19",
         "clsx": "^2.1.1",
@@ -641,40 +635,42 @@
         "react-remove-scroll": "^2.7.2",
         "type-fest": "^5.6.0"
       },
+      "integrity": "sha512-CicPg9i2dM2pGp1jj+dMiR/63OFDsPjgJke4v5+0nbfJ+C7gn4C+7ltrp4RIETDMZHcj0fFuDRG0qtbiyBxvWA==",
+      "license": "MIT",
       "peerDependencies": {
         "@mantine/hooks": "9.2.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@mantine/core/-/core-9.2.1.tgz",
+      "version": "9.2.1"
     },
     "node_modules/@mantine/dates": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-9.2.1.tgz",
-      "integrity": "sha512-cyRC8bnZ6W+SzQf/RM+/eDeWhZTZF148z+OcgqiERdkAujh0q88Ddybv/Hshv1EOf0rCe6oiHSZWxIxmUf7KAg==",
-      "license": "MIT",
       "dependencies": {
         "clsx": "^2.1.1"
       },
+      "integrity": "sha512-cyRC8bnZ6W+SzQf/RM+/eDeWhZTZF148z+OcgqiERdkAujh0q88Ddybv/Hshv1EOf0rCe6oiHSZWxIxmUf7KAg==",
+      "license": "MIT",
       "peerDependencies": {
         "@mantine/core": "9.2.1",
         "@mantine/hooks": "9.2.1",
         "dayjs": ">=1.0.0",
         "react": "^19.2.0",
         "react-dom": "^19.2.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@mantine/dates/-/dates-9.2.1.tgz",
+      "version": "9.2.1"
     },
     "node_modules/@mantine/hooks": {
-      "version": "9.2.1",
-      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.2.1.tgz",
       "integrity": "sha512-IX/ztVG9eWmQTRsN7G8odyW4JckNvN8qv5A2ULzXyazjtAKLuaUpuMz0c6XhRp10J0g4bVfV3rhrTgWeImqxqg==",
       "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@mantine/hooks/-/hooks-9.2.1.tgz",
+      "version": "9.2.1"
     },
     "node_modules/@melloware/react-logviewer": {
-      "version": "6.5.2",
-      "license": "MPL-2.0",
       "dependencies": {
         "hotkeys-js": "4.0.3",
         "immutable": "5.1.5",
@@ -682,310 +678,307 @@
         "react-string-replace": "2.0.1",
         "virtua": "0.49.0"
       },
+      "license": "MPL-2.0",
       "peerDependencies": {
         "react": ">=17.0.0",
         "react-dom": ">=17.0.0"
-      }
+      },
+      "version": "6.5.2"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
-      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@tybys/wasm-util": "^0.10.1"
       },
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "license": "MIT",
+      "optional": true,
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "version": "1.1.4"
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.130.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
-      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
-      }
+      },
+      "integrity": "sha512-ibD2usx9JRu7f5pu2tMKMI4cpA4NgXJQoYRP4pQ7Pxmn1l6k/53qWtQWZayhYy3X4QZkt90Ot+mJEaeXouio6Q==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.130.0.tgz",
+      "version": "0.130.0"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
-      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-fJI3I0r3C3Oj/zdBCpaCmBRZYf07xpaq4yCfDDoSFm+beWNzbIl26puW8RraUdugoJw/95zerNOn6jasAhzSmg==",
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
-      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-cKnAhWEsV7TPcA/5EAteDp6KcJZBQ2G+BqE7zayMMi7kMvwRsbv7WT9aOnn0WNl4SKEIf43vjS31iUPu80nzXg==",
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
-      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-YKrVwQjIRBPo+5G/u03wGjbdy4q7pyzCe93DK9VJ7zkVmeg8LJ7GbgsiHWdR4xSoe4CAXRD7Bcjgbtr64bkXNg==",
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
-      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-z/oBsREo46SsFqBwYtFe0kpJeBijAT48O/WXLI4suiCLBkr03RTtTJMCzSdDd2znlh8VJizL09XVkQgk8IZonw==",
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
-      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-ik8q7GM11zxvYxFc2PeDcT6TBvhCQMaUxfph/M5l9sKuTs/Sjg3L+Byw0F7w0ZVLBZmx30P+gG0ECzzN+MFcmQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
-      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-QoSx2EkyrrdZ6kcyE8stqZ62t0Yra8Fs5ia9lOxJrh6TMQJK7gQKmscdTHf7pOXKREKrVwOtJcQG3qVSfc866A==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
-      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-uwNwFpwKeNiZawfAWBgg0VIztPTV3ihhh1vV334h9ivnNLorxnQMU6Fz8wG1Zb4Qh9LC1/MkcyT3YlDXG3Rsgg==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
-      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "cpu": [
         "ppc64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-zY1bul7OWr7DFBiJ++wofXvnr8B45ce3QsQUhKrIhXsygAh7bTkwyeM1bi1a2g5C/yC/N8TZyGDEoMfm/l9mpg==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
-      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-0frlsT/f4Ft6I7SMESTKnF3cZsdicQn1dCMkF/jT9wDLE+gGoiQfv1nmT9e+s7s/fekvvy6tZM2jHvI2tkbJDQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
-      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-XABVmGp9Tg0WspTVvwduTc4fpqy6JnAUrSQe6OuyqD/03nI7r0O9OWUkMIwFrjKAIqolvqoA4ZrJppgwE0Gxmw==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
-      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-bV4fzswuzVcKD90o/VM6QqKxnxlDq0g2BISDLNVmxrnhpv1DDbyPhCIjYfvzYLV+MvkKKnQt2Q6AO86SEBULUQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
-      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-/Mh0Zhq3OP7fVs0kcQHZP6lZEthMGTaSf8UBQYSFEZDWGXXlEC+nJ6EqenaK2t4LBXMe3A+K/G2BVXXdtOr4PQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "openharmony"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
-      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@emnapi/core": "1.10.0",
         "@emnapi/runtime": "1.10.0",
         "@napi-rs/wasm-runtime": "^1.1.4"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
-      }
+      },
+      "integrity": "sha512-+1xc9X45l8ufsBAm6Gjvx2qDRIY9lTVt0cgWNcJ+1gdhXvkbxePA60yRTwSTuXL09CMhyJmjpV7E3NoyxbqFQQ==",
+      "license": "MIT",
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
-      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-1D+UqZdfnuR+Jy1GgMJwi85bD40H21uNmOPRWQhw4oRSuolZ/B5rixZ45DK2KXOTCvmVCecauWgEhbw8bI7tOw==",
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
-      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "integrity": "sha512-INAycaWuhlOK3wk4mRHGsdgwYWmd9cChdPdE9bwWmy6rn9VqVNYNFGhOdXrofXUxwHIncSiPNb8tNm8knDVIeQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "engines": {
-        "node": "^20.19.0 || >=22.12.0"
-      }
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
-      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
-      "license": "MIT"
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
-      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
         "enhanced-resolve": "^5.21.0",
@@ -994,17 +987,20 @@
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
         "tailwindcss": "4.3.0"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
-      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
+      "license": "MIT",
       "optionalDependencies": {
         "@tailwindcss/oxide-android-arm64": "4.3.0",
         "@tailwindcss/oxide-darwin-arm64": "4.3.0",
@@ -1018,165 +1014,164 @@
         "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
         "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
         "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
-      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
       "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
-      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
-      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
-      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
-      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
       "cpu": [
         "arm"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
-      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
-      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
-      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
-      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1188,9 +1183,6 @@
       "cpu": [
         "wasm32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@emnapi/core": "^1.10.0",
         "@emnapi/runtime": "^1.10.0",
@@ -1199,127 +1191,131 @@
         "@tybys/wasm-util": "^0.10.1",
         "tslib": "^2.8.1"
       },
+      "dev": true,
       "engines": {
         "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "dev": true,
-      "inBundle": true,
+      },
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
       "license": "MIT",
       "optional": true,
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "version": "4.3.0"
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/core": {
       "dependencies": {
         "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
-      }
+      },
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
+      "version": "1.10.0"
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
+      "version": "1.10.0"
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.1",
-      "dev": true,
-      "inBundle": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.4",
+      },
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
+      "version": "1.2.1"
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
       "dependencies": {
         "@tybys/wasm-util": "^0.10.1"
       },
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/Brooooooklyn"
       },
+      "inBundle": true,
+      "license": "MIT",
+      "optional": true,
       "peerDependencies": {
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
-      }
+      },
+      "version": "1.1.4"
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
+      "version": "0.10.1"
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi/node_modules/tslib": {
-      "version": "2.8.1",
       "dev": true,
       "inBundle": true,
       "license": "0BSD",
-      "optional": true
+      "optional": true,
+      "version": "2.8.1"
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
-      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 20"
+      },
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
       "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ],
-      "engines": {
-        "node": ">= 20"
-      }
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
-      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
         "@tailwindcss/node": "4.3.0",
         "@tailwindcss/oxide": "4.3.0",
         "postcss": "^8.5.10",
         "tailwindcss": "4.3.0"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/@tanstack/react-table": {
-      "version": "8.21.3",
-      "license": "MIT",
       "dependencies": {
         "@tanstack/table-core": "8.21.3"
       },
@@ -1330,151 +1326,148 @@
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
-      }
+      },
+      "version": "8.21.3"
     },
     "node_modules/@tanstack/table-core": {
-      "version": "8.21.3",
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
-      }
+      },
+      "license": "MIT",
+      "version": "8.21.3"
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.2",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
-      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
+      "license": "MIT",
+      "optional": true,
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "version": "0.10.2"
     },
     "node_modules/@types/debug": {
-      "version": "4.1.12",
-      "license": "MIT",
       "dependencies": {
         "@types/ms": "*"
-      }
+      },
+      "license": "MIT",
+      "version": "4.1.12"
     },
     "node_modules/@types/esrecurse": {
-      "version": "4.3.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.3.1"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.0.8"
     },
     "node_modules/@types/estree-jsx": {
-      "version": "1.0.5",
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "*"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.5"
     },
     "node_modules/@types/hast": {
-      "version": "3.0.4",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.4"
     },
     "node_modules/@types/json-schema": {
-      "version": "7.0.15",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "7.0.15"
     },
     "node_modules/@types/lodash": {
-      "version": "4.17.23",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.17.23"
     },
     "node_modules/@types/lodash-es": {
-      "version": "4.17.12",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/lodash": "*"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "4.17.12"
     },
     "node_modules/@types/mdast": {
-      "version": "4.0.4",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "*"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.4"
     },
     "node_modules/@types/ms": {
-      "version": "2.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.1.0"
     },
     "node_modules/@types/node": {
-      "version": "25.9.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
-      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "undici-types": ">=7.24.0 <7.24.7"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-AOQwYUNolgy3VosiRqXrACUXTN8nJUtPl7FJXMqZVyxiiCLhQuG3jXKvCS1ALr+Y2OmZhzzLVlYPEqJaiqkaJQ==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.9.0.tgz",
+      "version": "25.9.0"
     },
     "node_modules/@types/parse-json": {
-      "version": "4.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.0.2"
     },
     "node_modules/@types/prismjs": {
-      "version": "1.26.6",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.26.6"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "19.2.14"
     },
     "node_modules/@types/react-dom": {
-      "version": "19.2.3",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
-      }
+      },
+      "version": "19.2.3"
     },
     "node_modules/@types/react-syntax-highlighter": {
-      "version": "15.5.13",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@types/react": "*"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "15.5.13"
     },
     "node_modules/@types/react-transition-group": {
-      "version": "4.4.12",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*"
-      }
+      },
+      "version": "4.4.12"
     },
     "node_modules/@types/unist": {
-      "version": "3.0.3",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "3.0.3"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
-      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
         "@typescript-eslint/scope-manager": "8.59.3",
@@ -1485,6 +1478,7 @@
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1492,28 +1486,27 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-PwFvSKsXGShKGW6n5bZOhGHEcCZXM8HofLK9fNsEwZXzFRjoY+XT1Vsf1zgyXdwTr0ZYz1/2tkZ0DBTT9jZjhw==",
+      "license": "MIT",
       "peerDependencies": {
         "@typescript-eslint/parser": "^8.59.3",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.3.tgz",
+      "version": "8.59.3"
     },
     "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
-      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
+      },
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "version": "7.0.5"
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
-      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
@@ -1521,6 +1514,7 @@
         "@typescript-eslint/visitor-keys": "8.59.3",
         "debug": "^4.4.3"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1528,22 +1522,22 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-HPwA+hVkfcriajbNvTmZv4VRauibay+cWArYUYq7u7W7PmGShMxbPxLvrwDme55a6d5alG3nrYfhyJ/G28XlLg==",
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.3.tgz",
+      "version": "8.59.3"
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
-      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/tsconfig-utils": "^8.59.3",
         "@typescript-eslint/types": "^8.59.3",
         "debug": "^4.4.3"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1551,34 +1545,34 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-ECiUWa/KYRGDFUqTNehaRgzDshnJfkTABJxVemHk4ko22gcr0ukloKjWvyQ64g8YCV/UI47kN1dbmjf/GaQYng==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.3.tgz",
+      "version": "8.59.3"
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
-      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.59.3",
         "@typescript-eslint/visitor-keys": "8.59.3"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
+      },
+      "integrity": "sha512-t2LvZnoEfzKtnPjgeEu41xw5gxq9mQVfYy4OoZ4Vlt0sk3JwxmhCca/AR7DwOiHrjWgjAj6as4AhRLKSDfvZIA==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.3.tgz",
+      "version": "8.59.3"
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
-      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1586,16 +1580,15 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-PcIJHjmaREXLgIAIzLnSY9VucEzz8FKXsRgFa1DmdGCK/5tJpW03TKJF01Q6VZd1lLdz2sIKPWaDUZN9dp//dw==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.3.tgz",
+      "version": "8.59.3"
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
-      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.59.3",
         "@typescript-eslint/typescript-estree": "8.59.3",
@@ -1603,6 +1596,7 @@
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1610,31 +1604,30 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-g71d8QD8UaiHGvrJwyIS1hCX5r63w6Jll+4VEYhEAHXTDIqX1JgxhTAbEHtKntL9kuc4jRo7/GWw5xfCepSccQ==",
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.3.tgz",
+      "version": "8.59.3"
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
-      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
+      },
+      "integrity": "sha512-ePFoH0g4ludssdRFqqDxQePCxU4WQyRa9+XVwjm7yLn0FKhMeoetC+qBEEI1Eyb1pGSDveTIT09Bvw2WhlGayg==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.3.tgz",
+      "version": "8.59.3"
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
-      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/project-service": "8.59.3",
         "@typescript-eslint/tsconfig-utils": "8.59.3",
@@ -1646,6 +1639,7 @@
         "tinyglobby": "^0.2.15",
         "ts-api-utils": "^2.5.0"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1653,35 +1647,35 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-CbRjVRAf7Lr9Kr8RopKcbY45p2VfmmHrm0ygOCYFi7oU8q19m0Fs/6iHS7kNOmwpp+ob07ZVcAqlxUod9lYdmg==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.3.tgz",
+      "version": "8.59.3"
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
-      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
-      "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
+      "dev": true,
       "engines": {
         "node": ">=10"
-      }
+      },
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "version": "7.8.0"
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
-      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
         "@typescript-eslint/scope-manager": "8.59.3",
         "@typescript-eslint/types": "8.59.3",
         "@typescript-eslint/typescript-estree": "8.59.3"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -1689,45 +1683,47 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-JAvT14goBzRzzzZyqq3P9BLArIxTtQURUtFgQ/V7FO+eU+Gg6ES+5ymOPP1wRxXcxAYeivCk4uS3jCKWI1K8Zg==",
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.3.tgz",
+      "version": "8.59.3"
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
-      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/types": "8.59.3",
         "eslint-visitor-keys": "^5.0.0"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
+      },
+      "integrity": "sha512-f1UQF7ggd42YiwI5wGrRaPsa+P0CINBlrkLPmGfpq/u/I/oVtecoEIfFR9ag/oa1sLOsRNZ6xehf6qMZhQGBDg==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.3.tgz",
+      "version": "8.59.3"
     },
     "node_modules/@ungap/structured-clone": {
-      "version": "1.3.0",
-      "license": "ISC"
+      "license": "ISC",
+      "version": "1.3.0"
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
-      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@rolldown/pluginutils": "^1.0.0"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
+      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
+      "license": "MIT",
       "peerDependencies": {
         "@rolldown/plugin-babel": "^0.1.7 || ^0.2.0",
         "babel-plugin-react-compiler": "^1.0.0",
@@ -1740,45 +1736,59 @@
         "babel-plugin-react-compiler": {
           "optional": true
         }
-      }
+      },
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
+      "version": "6.0.2"
     },
     "node_modules/acorn": {
-      "version": "8.16.0",
-      "dev": true,
-      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
-      }
+      },
+      "license": "MIT",
+      "version": "8.16.0"
     },
     "node_modules/acorn-jsx": {
-      "version": "5.3.2",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
-      }
+      },
+      "version": "5.3.2"
     },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       },
+      "dev": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
-      }
+      },
+      "license": "MIT",
+      "version": "6.14.0"
     },
     "node_modules/autoprefixer": {
-      "version": "10.5.0",
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "dependencies": {
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
       "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
       "funding": [
         {
           "type": "opencollective",
@@ -1794,26 +1804,12 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "browserslist": "^4.28.2",
-        "caniuse-lite": "^1.0.30001787",
-        "fraction.js": "^5.3.4",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
       "peerDependencies": {
         "postcss": "^8.1.0"
-      }
+      },
+      "version": "10.5.0"
     },
     "node_modules/babel-plugin-macros": {
-      "version": "3.1.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "cosmiconfig": "^7.0.0",
@@ -1822,49 +1818,63 @@
       "engines": {
         "node": ">=10",
         "npm": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.0"
     },
     "node_modules/bail": {
-      "version": "2.0.2",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/balanced-match": {
-      "version": "4.0.4",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.4"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.20",
-      "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
       },
+      "dev": true,
       "engines": {
         "node": ">=6.0.0"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "2.10.20"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
+      "dev": true,
       "engines": {
         "node": "18 || 20 || >=22"
-      }
+      },
+      "license": "MIT",
+      "version": "5.0.5"
     },
     "node_modules/browserslist": {
-      "version": "4.28.2",
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.12",
+        "caniuse-lite": "^1.0.30001782",
+        "electron-to-chromium": "^1.5.328",
+        "node-releases": "^2.0.36",
+        "update-browserslist-db": "^1.2.3"
+      },
       "dev": true,
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      },
       "funding": [
         {
           "type": "opencollective",
@@ -1880,29 +1890,16 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "baseline-browser-mapping": "^2.10.12",
-        "caniuse-lite": "^1.0.30001782",
-        "electron-to-chromium": "^1.5.328",
-        "node-releases": "^2.0.36",
-        "update-browserslist-db": "^1.2.3"
-      },
-      "bin": {
-        "browserslist": "cli.js"
-      },
-      "engines": {
-        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
-      }
+      "version": "4.28.2"
     },
     "node_modules/callsites": {
-      "version": "3.1.0",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.0"
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001788",
       "dev": true,
       "funding": [
         {
@@ -1918,71 +1915,70 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "license": "CC-BY-4.0"
+      "license": "CC-BY-4.0",
+      "version": "1.0.30001788"
     },
     "node_modules/ccount": {
-      "version": "2.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/character-entities": {
-      "version": "2.0.2",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/character-entities-html4": {
-      "version": "2.1.0",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.1.0"
     },
     "node_modules/character-entities-legacy": {
-      "version": "3.0.0",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.0"
     },
     "node_modules/character-reference-invalid": {
-      "version": "2.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/clsx": {
-      "version": "2.1.1",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "2.1.1"
     },
     "node_modules/comma-separated-tokens": {
-      "version": "2.0.3",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.3"
     },
     "node_modules/convert-source-map": {
-      "version": "2.0.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.0"
     },
     "node_modules/cosmiconfig": {
-      "version": "7.1.0",
-      "license": "MIT",
       "dependencies": {
         "@types/parse-json": "^4.0.0",
         "import-fresh": "^3.2.1",
@@ -1992,144 +1988,144 @@
       },
       "engines": {
         "node": ">=10"
-      }
+      },
+      "license": "MIT",
+      "version": "7.1.0"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.6",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       },
+      "dev": true,
       "engines": {
         "node": ">= 8"
-      }
+      },
+      "license": "MIT",
+      "version": "7.0.6"
     },
     "node_modules/csstype": {
-      "version": "3.2.3",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "3.2.3"
     },
     "node_modules/debug": {
-      "version": "4.4.3",
-      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
       },
+      "license": "MIT",
       "peerDependenciesMeta": {
         "supports-color": {
           "optional": true
         }
-      }
+      },
+      "version": "4.4.3"
     },
     "node_modules/decode-named-character-reference": {
-      "version": "1.3.0",
-      "license": "MIT",
       "dependencies": {
         "character-entities": "^2.0.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "1.3.0"
     },
     "node_modules/deep-is": {
-      "version": "0.1.4",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.1.4"
     },
     "node_modules/dequal": {
-      "version": "2.0.3",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.3"
     },
     "node_modules/detect-libc": {
-      "version": "2.1.2",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "2.1.2"
     },
     "node_modules/detect-node-es": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.1.0"
     },
     "node_modules/devlop": {
-      "version": "1.1.0",
-      "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "1.1.0"
     },
     "node_modules/dom-helpers": {
-      "version": "5.2.1",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.8.7",
         "csstype": "^3.0.2"
-      }
+      },
+      "license": "MIT",
+      "version": "5.2.1"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.340",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "version": "1.5.340"
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.3",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
-      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
         "tapable": "^2.3.3"
       },
+      "dev": true,
       "engines": {
         "node": ">=10.13.0"
-      }
+      },
+      "integrity": "sha512-QyL119InA+XXEkNLNTPCXPugSvOfhwv0JOlGNzvxs0hZaiHLNvXSpudUWsOlsXGWJh8G6ckCScEkVHfX3kw/2Q==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.3.tgz",
+      "version": "5.21.3"
     },
     "node_modules/error-ex": {
-      "version": "1.3.4",
-      "license": "MIT",
       "dependencies": {
         "is-arrayish": "^0.2.1"
-      }
+      },
+      "license": "MIT",
+      "version": "1.3.4"
     },
     "node_modules/escalade": {
-      "version": "3.2.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "3.2.0"
     },
     "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/eslint": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
-      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
-      "dev": true,
-      "license": "MIT",
+      "bin": {
+        "eslint": "bin/eslint.js"
+      },
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -2162,15 +2158,15 @@
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
-      "bin": {
-        "eslint": "bin/eslint.js"
-      },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
       },
+      "integrity": "sha512-loXy6bWOoP3EP6JA7jo6p5jMpBJmHmsNZM5SFRHLdh1MGOPurMnNBj4ZlAbaqUAaQWbCr7jHV4P7gzAyryZWkQ==",
+      "license": "MIT",
       "peerDependencies": {
         "jiti": "*"
       },
@@ -2178,12 +2174,11 @@
         "jiti": {
           "optional": true
         }
-      }
+      },
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.4.0.tgz",
+      "version": "10.4.0"
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.1.1",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.24.4",
         "@babel/parser": "^7.24.4",
@@ -2191,147 +2186,149 @@
         "zod": "^3.25.0 || ^4.0.0",
         "zod-validation-error": "^3.5.0 || ^4.0.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=18"
       },
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
-      }
+      },
+      "version": "7.1.1"
     },
     "node_modules/eslint-plugin-react-refresh": {
-      "version": "0.5.2",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "eslint": "^9 || ^10"
-      }
+      },
+      "version": "0.5.2"
     },
     "node_modules/eslint-scope": {
-      "version": "9.1.2",
-      "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "@types/esrecurse": "^4.3.1",
         "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
+      },
+      "license": "BSD-2-Clause",
+      "version": "9.1.2"
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
       "dev": true,
-      "license": "Apache-2.0",
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "5.0.1"
     },
     "node_modules/espree": {
-      "version": "11.2.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
         "eslint-visitor-keys": "^5.0.1"
       },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
+      },
+      "license": "BSD-2-Clause",
+      "version": "11.2.0"
     },
     "node_modules/esquery": {
-      "version": "1.7.0",
-      "dev": true,
-      "license": "BSD-3-Clause",
       "dependencies": {
         "estraverse": "^5.1.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=0.10"
-      }
+      },
+      "license": "BSD-3-Clause",
+      "version": "1.7.0"
     },
     "node_modules/esrecurse": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "estraverse": "^5.2.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=4.0"
-      }
+      },
+      "license": "BSD-2-Clause",
+      "version": "4.3.0"
     },
     "node_modules/estraverse": {
-      "version": "5.3.0",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=4.0"
-      }
+      },
+      "license": "BSD-2-Clause",
+      "version": "5.3.0"
     },
     "node_modules/estree-util-is-identifier-name": {
-      "version": "3.0.0",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.0"
     },
     "node_modules/esutils": {
-      "version": "2.0.3",
       "dev": true,
-      "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "BSD-2-Clause",
+      "version": "2.0.3"
     },
     "node_modules/extend": {
-      "version": "3.0.2",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "3.0.2"
     },
     "node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "3.1.3"
     },
     "node_modules/fast-json-stable-stringify": {
-      "version": "2.1.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.1.0"
     },
     "node_modules/fast-levenshtein": {
-      "version": "2.0.6",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.6"
     },
     "node_modules/fault": {
-      "version": "1.0.4",
-      "license": "MIT",
       "dependencies": {
         "format": "^0.2.0"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.4"
     },
     "node_modules/fdir": {
-      "version": "6.5.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "picomatch": "^3 || ^4"
       },
@@ -2339,165 +2336,164 @@
         "picomatch": {
           "optional": true
         }
-      }
+      },
+      "version": "6.5.0"
     },
     "node_modules/file-entry-cache": {
-      "version": "8.0.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flat-cache": "^4.0.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=16.0.0"
-      }
+      },
+      "license": "MIT",
+      "version": "8.0.0"
     },
     "node_modules/find-root": {
-      "version": "1.1.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.1.0"
     },
     "node_modules/find-up": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "5.0.0"
     },
     "node_modules/flat-cache": {
-      "version": "4.0.1",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "flatted": "^3.2.9",
         "keyv": "^4.5.4"
       },
+      "dev": true,
       "engines": {
         "node": ">=16"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.1"
     },
     "node_modules/flatted": {
-      "version": "3.4.2",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "version": "3.4.2"
     },
     "node_modules/format": {
-      "version": "0.2.2",
       "engines": {
         "node": ">=0.4.x"
-      }
+      },
+      "version": "0.2.2"
     },
     "node_modules/fraction.js": {
-      "version": "5.3.4",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": "*"
       },
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/rawify"
-      }
+      },
+      "license": "MIT",
+      "version": "5.3.4"
     },
     "node_modules/fsevents": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "dev": true,
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      },
       "hasInstallScript": true,
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
       "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ],
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-      }
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "version": "2.3.3"
     },
     "node_modules/function-bind": {
-      "version": "1.1.2",
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "license": "MIT",
+      "version": "1.1.2"
     },
     "node_modules/gensync": {
-      "version": "1.0.0-beta.2",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.0-beta.2"
     },
     "node_modules/get-nonce": {
-      "version": "1.0.1",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.1"
     },
     "node_modules/glob-parent": {
-      "version": "6.0.2",
-      "dev": true,
-      "license": "ISC",
       "dependencies": {
         "is-glob": "^4.0.3"
       },
+      "dev": true,
       "engines": {
         "node": ">=10.13.0"
-      }
+      },
+      "license": "ISC",
+      "version": "6.0.2"
     },
     "node_modules/globals": {
-      "version": "17.6.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
-      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "version": "17.6.0"
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
-      "license": "ISC"
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "version": "4.2.11"
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
       },
       "engines": {
         "node": ">= 0.4"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/hast-util-parse-selector": {
-      "version": "4.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/hast-util-to-jsx-runtime": {
-      "version": "2.3.6",
-      "license": "MIT",
       "dependencies": {
         "@types/estree": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -2518,22 +2514,22 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "2.3.6"
     },
     "node_modules/hast-util-whitespace": {
-      "version": "3.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.0"
     },
     "node_modules/hastscript": {
-      "version": "9.0.1",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "comma-separated-tokens": "^2.0.0",
@@ -2544,79 +2540,79 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "9.0.1"
     },
     "node_modules/hermes-estree": {
-      "version": "0.25.1",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.25.1"
     },
     "node_modules/hermes-parser": {
-      "version": "0.25.1",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
-      }
+      },
+      "dev": true,
+      "license": "MIT",
+      "version": "0.25.1"
     },
     "node_modules/highlight.js": {
-      "version": "10.7.3",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": "*"
-      }
+      },
+      "license": "BSD-3-Clause",
+      "version": "10.7.3"
     },
     "node_modules/highlightjs-vue": {
-      "version": "1.0.0",
-      "license": "CC0-1.0"
+      "license": "CC0-1.0",
+      "version": "1.0.0"
     },
     "node_modules/hoist-non-react-statics": {
-      "version": "3.3.2",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "react-is": "^16.7.0"
-      }
+      },
+      "license": "BSD-3-Clause",
+      "version": "3.3.2"
     },
     "node_modules/hotkeys-js": {
-      "version": "4.0.3",
-      "license": "MIT",
       "funding": {
         "url": "https://jaywcjlove.github.io/#/sponsor"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.3"
     },
     "node_modules/html-url-attributes": {
-      "version": "3.0.1",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.1"
     },
     "node_modules/ignore": {
-      "version": "5.3.2",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
+      },
+      "license": "MIT",
+      "version": "5.3.2"
     },
     "node_modules/immer": {
-      "version": "11.1.8",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
-      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
-      "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
-      }
+      },
+      "integrity": "sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.8.tgz",
+      "version": "11.1.8"
     },
     "node_modules/immutable": {
-      "version": "5.1.5",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "5.1.5"
     },
     "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "license": "MIT",
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -2626,31 +2622,31 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "3.3.1"
     },
     "node_modules/imurmurhash": {
-      "version": "0.1.4",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.8.19"
-      }
+      },
+      "license": "MIT",
+      "version": "0.1.4"
     },
     "node_modules/inline-style-parser": {
-      "version": "0.2.7",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.2.7"
     },
     "node_modules/is-alphabetical": {
-      "version": "2.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/is-alphanumerical": {
-      "version": "2.0.1",
-      "license": "MIT",
       "dependencies": {
         "is-alphabetical": "^2.0.0",
         "is-decimal": "^2.0.0"
@@ -2658,15 +2654,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.2.1"
     },
     "node_modules/is-core-module": {
-      "version": "2.16.1",
-      "license": "MIT",
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -2675,139 +2671,139 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "license": "MIT",
+      "version": "2.16.1"
     },
     "node_modules/is-decimal": {
-      "version": "2.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/is-extglob": {
-      "version": "2.1.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "MIT",
+      "version": "2.1.1"
     },
     "node_modules/is-glob": {
-      "version": "4.0.3",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.3"
     },
     "node_modules/is-hexadecimal": {
-      "version": "2.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "4.1.0"
     },
     "node_modules/isexe": {
-      "version": "2.0.0",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "version": "2.0.0"
     },
     "node_modules/jiti": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
-      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
-      "dev": true,
-      "license": "MIT",
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "version": "2.7.0"
     },
     "node_modules/js-tokens": {
-      "version": "4.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/jsesc": {
-      "version": "3.1.0",
-      "license": "MIT",
       "bin": {
         "jsesc": "bin/jsesc"
       },
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.0"
     },
     "node_modules/json-buffer": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "license": "MIT"
-    },
-    "node_modules/json-schema-traverse": {
-      "version": "0.4.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-stable-stringify-without-jsonify": {
-      "version": "1.0.1",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json5": {
-      "version": "2.2.3",
       "dev": true,
       "license": "MIT",
+      "version": "3.0.1"
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "license": "MIT",
+      "version": "2.3.1"
+    },
+    "node_modules/json-schema-traverse": {
+      "dev": true,
+      "license": "MIT",
+      "version": "0.4.1"
+    },
+    "node_modules/json-stable-stringify-without-jsonify": {
+      "dev": true,
+      "license": "MIT",
+      "version": "1.0.1"
+    },
+    "node_modules/json5": {
       "bin": {
         "json5": "lib/cli.js"
       },
+      "dev": true,
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "2.2.3"
     },
     "node_modules/keyv": {
-      "version": "4.5.4",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "json-buffer": "3.0.1"
-      }
-    },
-    "node_modules/levn": {
-      "version": "0.4.1",
+      },
       "dev": true,
       "license": "MIT",
+      "version": "4.5.4"
+    },
+    "node_modules/levn": {
       "dependencies": {
         "prelude-ls": "^1.2.1",
         "type-check": "~0.4.0"
       },
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
+      },
+      "license": "MIT",
+      "version": "0.4.1"
     },
     "node_modules/lightningcss": {
-      "version": "1.32.0",
-      "dev": true,
-      "license": "MPL-2.0",
       "dependencies": {
         "detect-libc": "^2.0.3"
       },
+      "dev": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -2815,6 +2811,7 @@
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
       },
+      "license": "MPL-2.0",
       "optionalDependencies": {
         "lightningcss-android-arm64": "1.32.0",
         "lightningcss-darwin-arm64": "1.32.0",
@@ -2827,278 +2824,277 @@
         "lightningcss-linux-x64-musl": "1.32.0",
         "lightningcss-win32-arm64-msvc": "1.32.0",
         "lightningcss-win32-x64-msvc": "1.32.0"
-      }
+      },
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-android-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
-      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "android"
       ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-darwin-arm64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
-      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-darwin-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
-      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-freebsd-x64": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
-      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "cpu": [
         "x64"
       ],
       "dev": true,
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
       "license": "MPL-2.0",
       "optional": true,
       "os": [
         "freebsd"
       ],
-      "engines": {
-        "node": ">= 12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/parcel"
-      }
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-linux-arm-gnueabihf": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
-      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-linux-arm64-gnu": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
-      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-linux-arm64-musl": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
-      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-linux-x64-gnu": {
-      "version": "1.32.0",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-linux-x64-musl": {
-      "version": "1.32.0",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-win32-arm64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
-      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lightningcss-win32-x64-msvc": {
-      "version": "1.32.0",
-      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
-      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "license": "MPL-2.0",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
       "engines": {
         "node": ">= 12.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
-      }
+      },
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "version": "1.32.0"
     },
     "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.2.4"
     },
     "node_modules/locate-path": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-locate": "^5.0.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "6.0.0"
     },
     "node_modules/lodash-es": {
-      "version": "4.18.1",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.18.1"
     },
     "node_modules/longest-streak": {
-      "version": "3.1.0",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.0"
     },
     "node_modules/loose-envify": {
-      "version": "1.4.0",
-      "license": "MIT",
+      "bin": {
+        "loose-envify": "cli.js"
+      },
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
-      "bin": {
-        "loose-envify": "cli.js"
-      }
+      "license": "MIT",
+      "version": "1.4.0"
     },
     "node_modules/lowlight": {
-      "version": "1.20.0",
-      "license": "MIT",
       "dependencies": {
         "fault": "^1.0.0",
         "highlight.js": "~10.7.0"
@@ -3106,29 +3102,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "1.20.0"
     },
     "node_modules/lru-cache": {
-      "version": "5.1.1",
-      "dev": true,
-      "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
-      }
+      },
+      "dev": true,
+      "license": "ISC",
+      "version": "5.1.1"
     },
     "node_modules/magic-string": {
-      "version": "0.30.21",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
-      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.5"
-      }
+      },
+      "dev": true,
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "version": "0.30.21"
     },
     "node_modules/mdast-util-from-markdown": {
-      "version": "2.0.2",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -3146,11 +3142,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/mdast-util-mdx-expression": {
-      "version": "2.0.1",
-      "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -3162,11 +3158,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/mdast-util-mdx-jsx": {
-      "version": "3.2.0",
-      "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -3184,11 +3180,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "3.2.0"
     },
     "node_modules/mdast-util-mdxjs-esm": {
-      "version": "2.0.1",
-      "license": "MIT",
       "dependencies": {
         "@types/estree-jsx": "^1.0.0",
         "@types/hast": "^3.0.0",
@@ -3200,11 +3196,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/mdast-util-phrasing": {
-      "version": "4.1.0",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "unist-util-is": "^6.0.0"
@@ -3212,11 +3208,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "4.1.0"
     },
     "node_modules/mdast-util-to-hast": {
-      "version": "13.2.1",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -3231,11 +3227,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "13.2.1"
     },
     "node_modules/mdast-util-to-markdown": {
-      "version": "2.1.2",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "@types/unist": "^3.0.0",
@@ -3250,36 +3246,26 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "2.1.2"
     },
     "node_modules/mdast-util-to-string": {
-      "version": "4.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/memoize-one": {
-      "version": "6.0.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "6.0.0"
     },
     "node_modules/micromark": {
-      "version": "4.0.2",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "@types/debug": "^4.0.0",
         "debug": "^4.0.0",
@@ -3298,10 +3284,7 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-core-commonmark": {
-      "version": "2.0.3",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3313,6 +3296,9 @@
         }
       ],
       "license": "MIT",
+      "version": "4.0.2"
+    },
+    "node_modules/micromark-core-commonmark": {
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "devlop": "^1.0.0",
@@ -3330,10 +3316,7 @@
         "micromark-util-subtokenize": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-destination": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3345,14 +3328,14 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.3"
+    },
+    "node_modules/micromark-factory-destination": {
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-factory-label": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3364,15 +3347,33 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-factory-label": {
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-factory-space": {
-      "version": "2.0.1",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3384,13 +3385,15 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
+      "version": "2.0.1"
     },
     "node_modules/micromark-factory-title": {
-      "version": "2.0.1",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3402,35 +3405,15 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "micromark-factory-space": "^2.0.0",
-        "micromark-util-character": "^2.0.0",
-        "micromark-util-symbol": "^2.0.0",
-        "micromark-util-types": "^2.0.0"
-      }
+      "version": "2.0.1"
     },
     "node_modules/micromark-factory-whitespace": {
-      "version": "2.0.1",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "micromark-factory-space": "^2.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-character": {
-      "version": "2.1.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3442,30 +3425,30 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-util-character": {
       "dependencies": {
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.1.1"
     },
     "node_modules/micromark-util-chunked": {
-      "version": "2.0.1",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-classify-character": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3477,14 +3460,14 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-util-classify-character": {
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-combine-extensions": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3496,30 +3479,30 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-util-combine-extensions": {
       "dependencies": {
         "micromark-util-chunked": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-decode-numeric-character-reference": {
-      "version": "2.0.2",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-decode-string": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3531,15 +3514,29 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.2"
+    },
+    "node_modules/micromark-util-decode-string": {
       "dependencies": {
         "decode-named-character-reference": "^1.0.0",
         "micromark-util-character": "^2.0.0",
         "micromark-util-decode-numeric-character-reference": "^2.0.0",
         "micromark-util-symbol": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-encode": {
-      "version": "2.0.1",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3550,10 +3547,10 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-html-tag-name": {
-      "version": "2.0.1",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3564,44 +3561,30 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-normalize-identifier": {
-      "version": "2.0.1",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-symbol": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-resolve-all": {
-      "version": "2.0.1",
-      "funding": [
-        {
-          "type": "GitHub Sponsors",
-          "url": "https://github.com/sponsors/unifiedjs"
-        },
-        {
-          "type": "OpenCollective",
-          "url": "https://opencollective.com/unified"
-        }
-      ],
-      "license": "MIT",
       "dependencies": {
         "micromark-util-types": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-sanitize-uri": {
-      "version": "2.0.1",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3613,14 +3596,14 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
       "dependencies": {
         "micromark-util-character": "^2.0.0",
         "micromark-util-encode": "^2.0.0",
         "micromark-util-symbol": "^2.0.0"
-      }
-    },
-    "node_modules/micromark-util-subtokenize": {
-      "version": "2.1.0",
+      },
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3632,15 +3615,29 @@
         }
       ],
       "license": "MIT",
+      "version": "2.0.1"
+    },
+    "node_modules/micromark-util-subtokenize": {
       "dependencies": {
         "devlop": "^1.0.0",
         "micromark-util-chunked": "^2.0.0",
         "micromark-util-symbol": "^2.0.0",
         "micromark-util-types": "^2.0.0"
-      }
+      },
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "version": "2.1.0"
     },
     "node_modules/micromark-util-symbol": {
-      "version": "2.0.1",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3651,10 +3648,10 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/micromark-util-types": {
-      "version": "2.0.2",
       "funding": [
         {
           "type": "GitHub Sponsors",
@@ -3665,70 +3662,68 @@
           "url": "https://opencollective.com/unified"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/minimatch": {
-      "version": "10.2.4",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
       "dependencies": {
         "brace-expansion": "^5.0.2"
       },
+      "dev": true,
       "engines": {
         "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
+      },
+      "license": "BlueOak-1.0.0",
+      "version": "10.2.4"
     },
     "node_modules/mitt": {
-      "version": "3.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "3.0.1"
     },
     "node_modules/ms": {
-      "version": "2.1.3",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.1.3"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
       "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      },
       "funding": [
         {
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "license": "MIT",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "version": "3.3.12"
     },
     "node_modules/natural-compare": {
-      "version": "1.4.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.4.0"
     },
     "node_modules/node-releases": {
-      "version": "2.0.37",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.37"
     },
     "node_modules/object-assign": {
-      "version": "4.1.1",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "MIT",
+      "version": "4.1.1"
     },
     "node_modules/optionator": {
-      "version": "0.9.4",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "deep-is": "^0.1.3",
         "fast-levenshtein": "^2.0.6",
@@ -3737,51 +3732,52 @@
         "type-check": "^0.4.0",
         "word-wrap": "^1.2.5"
       },
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
+      },
+      "license": "MIT",
+      "version": "0.9.4"
     },
     "node_modules/p-limit": {
-      "version": "3.1.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "yocto-queue": "^0.1.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.0"
     },
     "node_modules/p-locate": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "p-limit": "^3.0.2"
       },
+      "dev": true,
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "5.0.0"
     },
     "node_modules/parent-module": {
-      "version": "1.0.1",
-      "license": "MIT",
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.1"
     },
     "node_modules/parse-entities": {
-      "version": "4.0.2",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^2.0.0",
         "character-entities-legacy": "^3.0.0",
@@ -3794,15 +3790,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.2"
     },
     "node_modules/parse-entities/node_modules/@types/unist": {
-      "version": "2.0.11",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.11"
     },
     "node_modules/parse-json": {
-      "version": "5.2.0",
-      "license": "MIT",
       "dependencies": {
         "@babel/code-frame": "^7.0.0",
         "error-ex": "^1.3.1",
@@ -3814,55 +3810,62 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "5.2.0"
     },
     "node_modules/path-exists": {
-      "version": "4.0.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/path-key": {
-      "version": "3.1.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "MIT",
+      "version": "3.1.1"
     },
     "node_modules/path-parse": {
-      "version": "1.0.7",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "1.0.7"
     },
     "node_modules/path-type": {
-      "version": "4.0.0",
-      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/picocolors": {
-      "version": "1.1.1",
-      "license": "ISC"
+      "license": "ISC",
+      "version": "1.1.1"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=12"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.4"
     },
     "node_modules/postcss": {
-      "version": "8.5.15",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
-      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
       "dev": true,
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
       "funding": [
         {
           "type": "opencollective",
@@ -3877,87 +3880,78 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.12",
-        "picocolors": "^1.1.1",
-        "source-map-js": "^1.2.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "version": "8.5.15"
     },
     "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.2.0"
     },
     "node_modules/prelude-ls": {
-      "version": "1.2.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
+      },
+      "license": "MIT",
+      "version": "1.2.1"
     },
     "node_modules/prismjs": {
-      "version": "1.30.0",
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "1.30.0"
     },
     "node_modules/prop-types": {
-      "version": "15.8.1",
-      "license": "MIT",
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
-      }
+      },
+      "license": "MIT",
+      "version": "15.8.1"
     },
     "node_modules/property-information": {
-      "version": "7.1.0",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "7.1.0"
     },
     "node_modules/punycode": {
-      "version": "2.3.1",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
-      }
+      },
+      "license": "MIT",
+      "version": "2.3.1"
     },
     "node_modules/react": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
-      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "integrity": "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.6.tgz",
+      "version": "19.2.6"
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
-      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
-      "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
+      "integrity": "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^19.2.6"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.6.tgz",
+      "version": "19.2.6"
     },
     "node_modules/react-hook-form": {
-      "version": "7.76.0",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.76.0.tgz",
-      "integrity": "sha512-eKtLGgFeSgkHqQD8J59AMZ9a4uD1D83iSIzt4YlTGD7liDen5rrjcUO1rVIGd9yC1gofryjtHbv+4ny4hkLWlw==",
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
@@ -3965,17 +3959,19 @@
         "type": "opencollective",
         "url": "https://opencollective.com/react-hook-form"
       },
+      "integrity": "sha512-eKtLGgFeSgkHqQD8J59AMZ9a4uD1D83iSIzt4YlTGD7liDen5rrjcUO1rVIGd9yC1gofryjtHbv+4ny4hkLWlw==",
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.76.0.tgz",
+      "version": "7.76.0"
     },
     "node_modules/react-is": {
-      "version": "16.13.1",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "16.13.1"
     },
     "node_modules/react-markdown": {
-      "version": "10.1.0",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -3993,22 +3989,22 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": ">=18",
         "react": ">=18"
-      }
+      },
+      "version": "10.1.0"
     },
     "node_modules/react-number-format": {
-      "version": "5.4.5",
       "license": "MIT",
       "peerDependencies": {
         "react": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^0.14 || ^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
+      },
+      "version": "5.4.5"
     },
     "node_modules/react-remove-scroll": {
-      "version": "2.7.2",
-      "license": "MIT",
       "dependencies": {
         "react-remove-scroll-bar": "^2.3.7",
         "react-style-singleton": "^2.2.3",
@@ -4019,6 +4015,7 @@
       "engines": {
         "node": ">=10"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
@@ -4027,11 +4024,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "2.7.2"
     },
     "node_modules/react-remove-scroll-bar": {
-      "version": "2.3.8",
-      "license": "MIT",
       "dependencies": {
         "react-style-singleton": "^2.2.2",
         "tslib": "^2.0.0"
@@ -4039,6 +4035,7 @@
       "engines": {
         "node": ">=10"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -4047,11 +4044,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "2.3.8"
     },
     "node_modules/react-select": {
-      "version": "5.10.2",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.12.0",
         "@emotion/cache": "^11.4.0",
@@ -4063,18 +4059,18 @@
         "react-transition-group": "^4.3.0",
         "use-isomorphic-layout-effect": "^1.2.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
+      },
+      "version": "5.10.2"
     },
     "node_modules/react-string-replace": {
-      "version": "2.0.1",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "2.0.1"
     },
     "node_modules/react-style-singleton": {
-      "version": "2.2.3",
-      "license": "MIT",
       "dependencies": {
         "get-nonce": "^1.0.0",
         "tslib": "^2.0.0"
@@ -4082,6 +4078,7 @@
       "engines": {
         "node": ">=10"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
@@ -4090,11 +4087,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "2.2.3"
     },
     "node_modules/react-syntax-highlighter": {
-      "version": "16.1.1",
-      "license": "MIT",
       "dependencies": {
         "@babel/runtime": "^7.28.4",
         "highlight.js": "^10.4.1",
@@ -4106,27 +4102,27 @@
       "engines": {
         "node": ">= 16.20.2"
       },
+      "license": "MIT",
       "peerDependencies": {
         "react": ">= 0.14.0"
-      }
+      },
+      "version": "16.1.1"
     },
     "node_modules/react-transition-group": {
-      "version": "4.4.5",
-      "license": "BSD-3-Clause",
       "dependencies": {
         "@babel/runtime": "^7.5.5",
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
       },
+      "license": "BSD-3-Clause",
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
-      }
+      },
+      "version": "4.4.5"
     },
     "node_modules/refractor": {
-      "version": "5.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/prismjs": "^1.0.0",
@@ -4136,11 +4132,11 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "5.0.0"
     },
     "node_modules/remark-parse": {
-      "version": "11.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/mdast": "^4.0.0",
         "mdast-util-from-markdown": "^2.0.0",
@@ -4150,11 +4146,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "11.0.0"
     },
     "node_modules/remark-rehype": {
-      "version": "11.1.2",
-      "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.0",
         "@types/mdast": "^4.0.0",
@@ -4165,49 +4161,49 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "11.1.2"
     },
     "node_modules/resolve": {
-      "version": "1.22.11",
-      "license": "MIT",
+      "bin": {
+        "resolve": "bin/resolve"
+      },
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
         "supports-preserve-symlinks-flag": "^1.0.0"
-      },
-      "bin": {
-        "resolve": "bin/resolve"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "license": "MIT",
+      "version": "1.22.11"
     },
     "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "license": "MIT",
       "engines": {
         "node": ">=4"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/rolldown": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
-      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
-      "dev": true,
-      "license": "MIT",
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
       "dependencies": {
         "@oxc-project/types": "=0.130.0",
         "@rolldown/pluginutils": "^1.0.0"
       },
-      "bin": {
-        "rolldown": "bin/cli.mjs"
-      },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
+      "integrity": "sha512-X0KQHljNnEkWNqqiz9zJrGunh1B0HgOxLXvnFpCOcadzcy5qohZ3tqMEUg00vncoRovXuK3ZqCT9KnnKzoInFQ==",
+      "license": "MIT",
       "optionalDependencies": {
         "@rolldown/binding-android-arm64": "1.0.1",
         "@rolldown/binding-darwin-arm64": "1.0.1",
@@ -4224,65 +4220,65 @@
         "@rolldown/binding-wasm32-wasi": "1.0.1",
         "@rolldown/binding-win32-arm64-msvc": "1.0.1",
         "@rolldown/binding-win32-x64-msvc": "1.0.1"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.1.tgz",
+      "version": "1.0.1"
     },
     "node_modules/scheduler": {
-      "version": "0.27.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "0.27.0"
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "dev": true,
-      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
-      }
+      },
+      "dev": true,
+      "license": "ISC",
+      "version": "6.3.1"
     },
     "node_modules/shebang-command": {
-      "version": "2.0.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
       },
+      "dev": true,
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.0"
     },
     "node_modules/shebang-regex": {
-      "version": "3.0.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.0"
     },
     "node_modules/source-map": {
-      "version": "0.5.7",
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "BSD-3-Clause",
+      "version": "0.5.7"
     },
     "node_modules/source-map-js": {
-      "version": "1.2.1",
       "dev": true,
-      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "BSD-3-Clause",
+      "version": "1.2.1"
     },
     "node_modules/space-separated-tokens": {
-      "version": "2.0.2",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.2"
     },
     "node_modules/stringify-entities": {
-      "version": "4.0.4",
-      "license": "MIT",
       "dependencies": {
         "character-entities-html4": "^2.0.0",
         "character-entities-legacy": "^3.0.0"
@@ -4290,133 +4286,133 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.4"
     },
     "node_modules/style-to-js": {
-      "version": "1.1.21",
-      "license": "MIT",
       "dependencies": {
         "style-to-object": "1.0.14"
-      }
+      },
+      "license": "MIT",
+      "version": "1.1.21"
     },
     "node_modules/style-to-object": {
-      "version": "1.0.14",
-      "license": "MIT",
       "dependencies": {
         "inline-style-parser": "0.2.7"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.14"
     },
     "node_modules/stylis": {
-      "version": "4.2.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "4.2.0"
     },
     "node_modules/supports-preserve-symlinks-flag": {
-      "version": "1.0.0",
-      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.0"
     },
     "node_modules/tabbable": {
-      "version": "6.4.0",
-      "license": "MIT"
+      "license": "MIT",
+      "version": "6.4.0"
     },
     "node_modules/tagged-tag": {
-      "version": "1.0.0",
-      "license": "MIT",
       "engines": {
         "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "1.0.0"
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
-      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "dev": true,
-      "license": "MIT"
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "version": "4.3.0"
     },
     "node_modules/tapable": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=6"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
-      }
+      },
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "version": "2.3.3"
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
         "picomatch": "^4.0.4"
       },
+      "dev": true,
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
-      }
+      },
+      "license": "MIT",
+      "version": "0.2.16"
     },
     "node_modules/trim-lines": {
-      "version": "3.0.1",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "3.0.1"
     },
     "node_modules/trough": {
-      "version": "2.2.0",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.2.0"
     },
     "node_modules/ts-api-utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
-      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.12"
       },
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "license": "MIT",
       "peerDependencies": {
         "typescript": ">=4.8.4"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "version": "2.5.0"
     },
     "node_modules/tslib": {
-      "version": "2.8.1",
-      "license": "0BSD"
+      "license": "0BSD",
+      "version": "2.8.1"
     },
     "node_modules/type-check": {
-      "version": "0.4.0",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "prelude-ls": "^1.2.1"
       },
+      "dev": true,
       "engines": {
         "node": ">= 0.8.0"
-      }
+      },
+      "license": "MIT",
+      "version": "0.4.0"
     },
     "node_modules/type-fest": {
-      "version": "5.6.0",
-      "license": "(MIT OR CC0-1.0)",
       "dependencies": {
         "tagged-tag": "^1.0.0"
       },
@@ -4425,32 +4421,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "(MIT OR CC0-1.0)",
+      "version": "5.6.0"
     },
     "node_modules/typescript": {
-      "version": "6.0.3",
-      "dev": true,
-      "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
+      "dev": true,
       "engines": {
         "node": ">=14.17"
-      }
+      },
+      "license": "Apache-2.0",
+      "version": "6.0.3"
     },
     "node_modules/typescript-eslint": {
-      "version": "8.59.3",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
-      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
-      "dev": true,
-      "license": "MIT",
       "dependencies": {
         "@typescript-eslint/eslint-plugin": "8.59.3",
         "@typescript-eslint/parser": "8.59.3",
         "@typescript-eslint/typescript-estree": "8.59.3",
         "@typescript-eslint/utils": "8.59.3"
       },
+      "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
@@ -4458,21 +4452,23 @@
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
+      "integrity": "sha512-KgusgyDgG4LI8Ih/sWaCtZ06tckLAS5CvT5A4D1Q7bYVoAAyzwiZvE4BmwDHkhRVkvhRBepKeASoFzQetha7Fg==",
+      "license": "MIT",
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
-      }
+      },
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.3.tgz",
+      "version": "8.59.3"
     },
     "node_modules/undici-types": {
-      "version": "7.24.6",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
-      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
       "dev": true,
-      "license": "MIT"
+      "integrity": "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==",
+      "license": "MIT",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.24.6.tgz",
+      "version": "7.24.6"
     },
     "node_modules/unified": {
-      "version": "11.0.5",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "bail": "^2.0.0",
@@ -4485,44 +4481,44 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "11.0.5"
     },
     "node_modules/unist-util-is": {
-      "version": "6.0.1",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "6.0.1"
     },
     "node_modules/unist-util-position": {
-      "version": "5.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "5.0.0"
     },
     "node_modules/unist-util-stringify-position": {
-      "version": "4.0.0",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.0"
     },
     "node_modules/unist-util-visit": {
-      "version": "5.1.0",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0",
@@ -4531,11 +4527,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "5.1.0"
     },
     "node_modules/unist-util-visit-parents": {
-      "version": "6.0.2",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-is": "^6.0.0"
@@ -4543,10 +4539,18 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "6.0.2"
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.2.3",
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
       "dev": true,
       "funding": [
         {
@@ -4563,34 +4567,27 @@
         }
       ],
       "license": "MIT",
-      "dependencies": {
-        "escalade": "^3.2.0",
-        "picocolors": "^1.1.1"
-      },
-      "bin": {
-        "update-browserslist-db": "cli.js"
-      },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
-      }
+      },
+      "version": "1.2.3"
     },
     "node_modules/uri-js": {
-      "version": "4.4.1",
-      "dev": true,
-      "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
-      }
+      },
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "version": "4.4.1"
     },
     "node_modules/use-callback-ref": {
-      "version": "1.3.3",
-      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
       },
       "engines": {
         "node": ">=10"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
@@ -4599,10 +4596,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "1.3.3"
     },
     "node_modules/use-isomorphic-layout-effect": {
-      "version": "1.2.1",
       "license": "MIT",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -4611,11 +4608,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "1.2.1"
     },
     "node_modules/use-sidecar": {
-      "version": "1.1.3",
-      "license": "MIT",
       "dependencies": {
         "detect-node-es": "^1.1.0",
         "tslib": "^2.0.0"
@@ -4623,6 +4619,7 @@
       "engines": {
         "node": ">=10"
       },
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
@@ -4631,11 +4628,10 @@
         "@types/react": {
           "optional": true
         }
-      }
+      },
+      "version": "1.1.3"
     },
     "node_modules/vfile": {
-      "version": "6.0.3",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "vfile-message": "^4.0.0"
@@ -4643,11 +4639,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "6.0.3"
     },
     "node_modules/vfile-message": {
-      "version": "4.0.3",
-      "license": "MIT",
       "dependencies": {
         "@types/unist": "^3.0.0",
         "unist-util-stringify-position": "^4.0.0"
@@ -4655,10 +4651,11 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
+      },
+      "license": "MIT",
+      "version": "4.0.3"
     },
     "node_modules/virtua": {
-      "version": "0.49.0",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.14.0",
@@ -4683,14 +4680,13 @@
         "vue": {
           "optional": true
         }
-      }
+      },
+      "version": "0.49.0"
     },
     "node_modules/vite": {
-      "version": "8.0.13",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
-      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
-      "dev": true,
-      "license": "MIT",
+      "bin": {
+        "vite": "bin/vite.js"
+      },
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -4698,15 +4694,15 @@
         "rolldown": "1.0.1",
         "tinyglobby": "^0.2.16"
       },
-      "bin": {
-        "vite": "bin/vite.js"
-      },
+      "dev": true,
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
       },
       "funding": {
         "url": "https://github.com/vitejs/vite?sponsor=1"
       },
+      "integrity": "sha512-MFtjBYgzmSxmgA4RAfjIyXWpGe1oALnjgUTzzV7QLx/TKxCzjtMH6Fd9/eVK+5Fg1qNoz5VAwsmMs/NofrmJvw==",
+      "license": "MIT",
       "optionalDependencies": {
         "fsevents": "~2.3.3"
       },
@@ -4761,38 +4757,38 @@
         "yaml": {
           "optional": true
         }
-      }
+      },
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.13.tgz",
+      "version": "8.0.13"
     },
     "node_modules/which": {
-      "version": "2.0.2",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "isexe": "^2.0.0"
-      },
       "bin": {
         "node-which": "bin/node-which"
       },
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "dev": true,
       "engines": {
         "node": ">= 8"
-      }
+      },
+      "license": "ISC",
+      "version": "2.0.2"
     },
     "node_modules/word-wrap": {
-      "version": "1.2.5",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
+      },
+      "license": "MIT",
+      "version": "1.2.5"
     },
     "node_modules/yallist": {
-      "version": "3.1.1",
       "dev": true,
-      "license": "ISC"
+      "license": "ISC",
+      "version": "3.1.1"
     },
     "node_modules/yaml": {
-      "version": "2.8.3",
-      "license": "ISC",
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -4801,45 +4797,49 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/eemeli"
-      }
+      },
+      "license": "ISC",
+      "version": "2.8.3"
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
+      },
+      "license": "MIT",
+      "version": "0.1.0"
     },
     "node_modules/zod": {
-      "version": "4.3.6",
       "dev": true,
-      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
-      }
+      },
+      "license": "MIT",
+      "version": "4.3.6"
     },
     "node_modules/zod-validation-error": {
-      "version": "4.0.2",
       "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
       },
+      "license": "MIT",
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
-      }
+      },
+      "version": "4.0.2"
     },
     "node_modules/zwitch": {
-      "version": "2.0.4",
-      "license": "MIT",
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
+      },
+      "license": "MIT",
+      "version": "2.0.4"
     }
-  }
+  },
+  "requires": true,
+  "version": "0.0.0"
 }

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -17,7 +17,7 @@
         "immer": "^11.1.8",
         "lodash-es": "^4.18.1",
         "react": "^19.2.7",
-        "react-dom": "^19.2.6",
+        "react-dom": "^19.2.7",
         "react-hook-form": "^7.76.0",
         "react-markdown": "^10.1.0",
         "react-select": "^5.10.2",
@@ -3838,13 +3838,15 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "19.2.6",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "license": "MIT",
       "dependencies": {
         "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^19.2.6"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-hook-form": {

--- a/webui/package.json
+++ b/webui/package.json
@@ -9,7 +9,7 @@
     "immer": "^11.1.8",
     "lodash-es": "^4.18.1",
     "react": "^19.2.6",
-    "react-dom": "^19.2.6",
+    "react-dom": "^19.2.7",
     "react-hook-form": "^7.76.0",
     "react-markdown": "^10.1.0",
     "react-select": "^5.10.2",

--- a/webui/package.json
+++ b/webui/package.json
@@ -9,7 +9,7 @@
     "immer": "^11.1.8",
     "lodash-es": "^4.18.1",
     "react": "^19.2.7",
-    "react-dom": "^19.2.6",
+    "react-dom": "^19.2.7",
     "react-hook-form": "^7.76.0",
     "react-markdown": "^10.1.0",
     "react-select": "^5.10.2",

--- a/webui/public/sw.js
+++ b/webui/public/sw.js
@@ -50,6 +50,14 @@ self.addEventListener('activate', (event) => {
   );
 });
 
+function pathIncludesApi(pathname) {
+  return pathname === '/api' || pathname.startsWith('/api/') || pathname.includes('/api/');
+}
+
+function pathIncludesWebLogs(pathname) {
+  return pathname.includes('/web/logs/');
+}
+
 // Fetch event - network-first strategy for API calls, cache-first for assets
 self.addEventListener('fetch', (event) => {
   const { request } = event;
@@ -61,12 +69,12 @@ self.addEventListener('fetch', (event) => {
   }
 
   // Skip log file requests - they can be very large and shouldn't be cached
-  if (url.pathname.startsWith('/web/logs/') && !url.pathname.endsWith('/download')) {
+  if (pathIncludesWebLogs(url.pathname) && !url.pathname.endsWith('/download')) {
     return;
   }
 
   // Network-first for API calls
-  if (url.pathname.startsWith('/api/')) {
+  if (pathIncludesApi(url.pathname)) {
     event.respondWith(
       fetch(request)
         .then((response) => {

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -10,6 +10,7 @@ import { SearchProvider, useSearch } from "./context/SearchContext";
 import { WebUIProvider, useWebUI } from "./context/WebUIContext";
 import { useNetworkStatus } from "./hooks/useNetworkStatus";
 import { getMeta, getStatus, triggerUpdate, logout, fetchWebToken } from "./api/client";
+import { webPath } from "./api/urlBase";
 import { LoginPage } from "./pages/LoginPage";
 import type { ArrInfo, MetaResponse } from "./api/types";
 import { IconImage } from "./components/IconImage";
@@ -383,7 +384,7 @@ function ChangelogModal({
                 <>
                   <a
                     className="btn primary"
-                    href={`/web/download-update`}
+                    href={webPath("/web/download-update")}
                     download={binaryDownloadName ?? undefined}
                     target="_blank"
                     rel="noreferrer"
@@ -1049,7 +1050,7 @@ function AppShell({ authRequired, onSignOut }: { authRequired: boolean; onSignOu
               GitHub
             </a>
             <a
-              href="/web/docs"
+              href={webPath("/web/docs")}
               target="_blank"
               rel="noreferrer"
               className="btn small ghost"

--- a/webui/src/App.tsx
+++ b/webui/src/App.tsx
@@ -27,6 +27,7 @@ import LidarrIcon from "./icons/lidarr.svg";
 import QbitIcon from "./icons/qbittorrent.svg";
 import ConfigIcon from "./icons/gear.svg";
 import logoUrl from "./assets/logov2-clean.svg";
+import { safeClick } from "./utils/safeClick";
 
 class ErrorBoundary extends React.Component<
   { children: React.ReactNode },
@@ -551,6 +552,22 @@ function AppShell({ authRequired, onSignOut }: { authRequired: boolean; onSignOu
   const [configDirty, setConfigDirty] = useState(false);
   const { push } = useToast();
   const { setValue: setSearchValue } = useSearch();
+
+  const switchTab = useCallback(
+    (tabId: Tab) => {
+      if (activeTab === "config" && tabId !== "config" && configDirty) {
+        const shouldLeave = window.confirm(
+          "You have unsaved configuration changes. Leave without saving?"
+        );
+        if (!shouldLeave) {
+          return;
+        }
+      }
+      setActiveTab(tabId);
+      setSearchValue("");
+    },
+    [activeTab, configDirty, setSearchValue]
+  );
   const { viewDensity, setViewDensity } = useWebUI();
   const isOnline = useNetworkStatus();
   const [meta, setMeta] = useState<MetaResponse | null>(null);
@@ -695,7 +712,7 @@ function AppShell({ authRequired, onSignOut }: { authRequired: boolean; onSignOu
           "config",
         ];
         if (tabIndex < tabIds.length) {
-          setActiveTab(tabIds[tabIndex]);
+          switchTab(tabIds[tabIndex]);
         }
         return;
       }
@@ -703,7 +720,7 @@ function AppShell({ authRequired, onSignOut }: { authRequired: boolean; onSignOu
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [setSearchValue, configuredArrTabs]);
+  }, [setSearchValue, configuredArrTabs, switchTab]);
 
   useEffect(() => {
     const id = window.setInterval(() => {
@@ -756,11 +773,16 @@ function AppShell({ authRequired, onSignOut }: { authRequired: boolean; onSignOu
   }, [refreshMeta, refreshStatus, activeTab]);
 
   useEffect(() => {
-    void refreshStatus();
+    const initialId = window.setTimeout(() => {
+      void refreshStatus();
+    }, 0);
     const id = window.setInterval(() => {
       void refreshStatus();
     }, 5 * 1000); // Refresh every 5 seconds for more dynamic tab loading
-    return () => window.clearInterval(id);
+    return () => {
+      window.clearTimeout(initialId);
+      window.clearInterval(id);
+    };
   }, [refreshStatus]);
 
   useEffect(() => {
@@ -1087,18 +1109,7 @@ function AppShell({ authRequired, onSignOut }: { authRequired: boolean; onSignOu
               type="button"
               key={tab.id}
               className={activeTab === tab.id ? "active" : ""}
-              onClick={() => {
-                if (activeTab === "config" && tab.id !== "config" && configDirty) {
-                  const shouldLeave = window.confirm(
-                    "You have unsaved configuration changes. Leave without saving?"
-                  );
-                  if (!shouldLeave) {
-                    return;
-                  }
-                }
-                setActiveTab(tab.id);
-                setSearchValue("");
-              }}
+              onClick={safeClick(() => switchTab(tab.id))}
             >
               <IconImage src={tab.icon} />
               <span>{tab.label}</span>

--- a/webui/src/api/client.ts
+++ b/webui/src/api/client.ts
@@ -19,6 +19,7 @@ import type {
   LidarrTracksResponse,
   StatusResponse,
 } from "./types";
+import { setUrlBaseFromMeta, webPath } from "./urlBase";
 
 export class AuthError extends Error {
   code?: string;
@@ -82,6 +83,13 @@ function clearStoredToken(): void {
   }
 }
 
+function resolveRequestInput(input: RequestInfo | URL): RequestInfo | URL {
+  if (typeof input === "string" && input.startsWith("/")) {
+    return webPath(input);
+  }
+  return input;
+}
+
 function buildInit(init: RequestInit | undefined, token: string | null): RequestInit {
   const headers = new Headers(init?.headers || {});
   Object.entries(JSON_HEADERS).forEach(([key, value]) => {
@@ -104,7 +112,7 @@ async function fetchWithAuthRetry<T>(
   retries = MAX_AUTH_RETRIES
 ): Promise<T> {
   const token = resolveToken();
-  const response = await fetch(input, buildInit(init, token));
+  const response = await fetch(resolveRequestInput(input), buildInit(init, token));
   if (response.status === 401 && retries > 0 && token) {
     clearStoredToken();
     return fetchWithAuthRetry(input, init, handler, retries - 1);
@@ -173,7 +181,9 @@ async function handleText(res: Response): Promise<string> {
 
 export async function getMeta(params?: { force?: boolean }): Promise<MetaResponse> {
   const query = params?.force ? "?force=1" : "";
-  return fetchJson<MetaResponse>(`/web/meta${query}`);
+  const meta = await fetchJson<MetaResponse>(`/web/meta${query}`);
+  setUrlBaseFromMeta(meta.url_base);
+  return meta;
 }
 
 export async function getStatus(): Promise<StatusResponse> {
@@ -236,7 +246,7 @@ export async function getLogTail(
 }
 
 export function getLogDownloadUrl(name: string): string {
-  return `/web/logs/${encodeURIComponent(name)}/download`;
+  return webPath(`/web/logs/${encodeURIComponent(name)}/download`);
 }
 
 export type ArrOpenItemKind = "movie" | "series" | "artist";
@@ -247,7 +257,7 @@ export function getArrOpenItemUrl(
   entryId: number
 ): string {
   const encodedCategory = encodeURIComponent(category);
-  return `/web/arr/${encodedCategory}/open/${kind}/${entryId}`;
+  return webPath(`/web/arr/${encodedCategory}/open/${kind}/${entryId}`);
 }
 
 export function getRadarrOpenMovieUrl(category: string, movieId: number): string {
@@ -445,7 +455,7 @@ export async function testArrConnection(
 }
 
 export async function login(req: LoginRequest): Promise<{ success: boolean }> {
-  const res = await fetch("/web/login", {
+  const res = await fetch(webPath("/web/login"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "include",
@@ -461,7 +471,7 @@ export async function login(req: LoginRequest): Promise<{ success: boolean }> {
 }
 
 export async function setPassword(req: SetPasswordRequest): Promise<{ success: boolean }> {
-  const res = await fetch("/web/auth/set-password", {
+  const res = await fetch(webPath("/web/auth/set-password"), {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     credentials: "include",
@@ -476,12 +486,12 @@ export async function setPassword(req: SetPasswordRequest): Promise<{ success: b
 }
 
 export async function logout(): Promise<void> {
-  await fetch("/web/logout", { method: "POST", credentials: "include" });
+  await fetch(webPath("/web/logout"), { method: "POST", credentials: "include" });
   clearStoredToken();
 }
 
 export async function fetchWebToken(): Promise<string | null> {
-  const res = await fetch("/web/token", { credentials: "include" });
+  const res = await fetch(webPath("/web/token"), { credentials: "include" });
   if (!res.ok) return null;
   const data = await res.json().catch(() => ({})) as Record<string, unknown>;
   return typeof data.token === "string" ? data.token : null;

--- a/webui/src/api/types.ts
+++ b/webui/src/api/types.ts
@@ -337,6 +337,7 @@ export interface MetaResponse {
   local_auth_enabled?: boolean;
   oidc_enabled?: boolean;
   setup_required?: boolean;
+  url_base?: string;
 }
 
 export interface LoginRequest {

--- a/webui/src/api/urlBase.ts
+++ b/webui/src/api/urlBase.ts
@@ -1,0 +1,32 @@
+/** Public URL path prefix when the WebUI is served under a subpath (e.g. /qbitrr). */
+let cachedUrlBaseFromMeta: string | null = null;
+
+/** Derive UrlBase from the current page pathname (e.g. /qbitrr/static/index.html). */
+export function pathnameUrlBase(): string {
+  const staticMatch = window.location.pathname.match(/^(.*)\/static\/index\.html$/);
+  return staticMatch ? staticMatch[1] : "";
+}
+
+/** Return the active UrlBase prefix (pathname first, then meta after load). */
+export function getUrlBase(): string {
+  if (cachedUrlBaseFromMeta !== null) {
+    return cachedUrlBaseFromMeta;
+  }
+  return pathnameUrlBase();
+}
+
+/** Store UrlBase from /web/meta so API calls match the configured prefix. */
+export function setUrlBaseFromMeta(base: string | undefined): void {
+  if (base !== undefined) {
+    cachedUrlBaseFromMeta = base;
+  }
+}
+
+/** Prefix an app-relative path (must start with /) with the active UrlBase. */
+export function webPath(path: string): string {
+  if (!path.startsWith("/")) {
+    throw new Error("webPath expects a path starting with /");
+  }
+  const base = getUrlBase();
+  return base ? `${base}${path}` : path;
+}

--- a/webui/src/api/urlBase.ts
+++ b/webui/src/api/urlBase.ts
@@ -1,10 +1,29 @@
 /** Public URL path prefix when the WebUI is served under a subpath (e.g. /qbitrr). */
 let cachedUrlBaseFromMeta: string | null = null;
 
-/** Derive UrlBase from the current page pathname (e.g. /qbitrr/static/index.html). */
+/** App paths that appear after an optional UrlBase prefix in the browser URL. */
+const PUBLIC_APP_PATH =
+  /^(.*?)(?:\/ui|\/login|\/health|\/sw\.js|\/static\/|\/web\/|\/api\/)(?:\/|$)/;
+
+/**
+ * Derive UrlBase from the current page URL.
+ * Works for /qbitrr/static/index.html, /qbitrr/ui, /qbitrr/web/docs, etc.
+ */
 export function pathnameUrlBase(): string {
-  const staticMatch = window.location.pathname.match(/^(.*)\/static\/index\.html$/);
-  return staticMatch ? staticMatch[1] : "";
+  const { pathname } = window.location;
+  const staticMatch = pathname.match(/^(.*)\/static\/index\.html$/);
+  if (staticMatch) {
+    return staticMatch[1];
+  }
+  const appMatch = pathname.match(PUBLIC_APP_PATH);
+  if (appMatch && appMatch[1]) {
+    return appMatch[1];
+  }
+  // Bare subpath entry (e.g. /qbitrr) before redirect to /qbitrr/ui
+  if (/^\/[^/]+$/.test(pathname)) {
+    return pathname;
+  }
+  return "";
 }
 
 /** Return the active UrlBase prefix (pathname first, then meta after load). */

--- a/webui/src/components/arr/ArrModal.tsx
+++ b/webui/src/components/arr/ArrModal.tsx
@@ -3,6 +3,7 @@ import type { JSX } from "react";
 import { createPortal } from "react-dom";
 import { IconImage } from "../IconImage";
 import CloseIcon from "../../icons/close.svg";
+import { safeClick, useSafeBackdropClose } from "../../utils/safeClick";
 
 interface ArrModalProps {
   title: string;
@@ -17,8 +18,15 @@ export function ArrModal({
   onClose,
   maxWidth = 560,
 }: ArrModalProps): JSX.Element {
+  const backdropHandlers = useSafeBackdropClose(onClose);
+
   return createPortal(
-    <div className="modal-backdrop" role="presentation" onClick={onClose}>
+    <div
+      className="modal-backdrop"
+      role="presentation"
+      onPointerDown={backdropHandlers.onPointerDown}
+      onPointerUp={backdropHandlers.onPointerUp}
+    >
       <div
         className="modal"
         style={{ maxWidth }}
@@ -29,7 +37,12 @@ export function ArrModal({
       >
         <div className="modal-header">
           <h2 id="arr-modal-title">{title}</h2>
-          <button type="button" className="btn ghost" onClick={onClose} aria-label="Close">
+          <button
+            type="button"
+            className="btn ghost"
+            onClick={safeClick(onClose)}
+            aria-label="Close"
+          >
             <IconImage src={CloseIcon} />
           </button>
         </div>

--- a/webui/src/pages/ConfigView.tsx
+++ b/webui/src/pages/ConfigView.tsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState, type JSX } from "react";
+import { createPortal } from "react-dom";
 import { produce } from "immer";
 import equal from "fast-deep-equal";
 import { get, set } from "lodash-es";
@@ -36,6 +37,7 @@ import AddIcon from "../icons/plus.svg";
 import SaveIcon from "../icons/check-mark.svg";
 import DeleteIcon from "../icons/trash.svg";
 import CloseIcon from "../icons/close.svg";
+import { safeClick } from "../utils/safeClick";
 
 type FieldType = "text" | "number" | "checkbox" | "password" | "select" | "tags" | "duration";
 
@@ -488,8 +490,11 @@ const QBIT_FIELDS: FieldDefinition[] = [
     label: "Host",
     path: ["Host"],
     type: "text",
-    required: true,
-    validate: (value) => {
+    validate: (value, context) => {
+      const disabled = Boolean(getValue(context.section ?? {}, ["Disabled"]));
+      if (disabled) {
+        return undefined;
+      }
       if (!String(value ?? "").trim()) {
         return "qBit Host is required.";
       }
@@ -698,7 +703,6 @@ const ARR_GENERAL_FIELDS: FieldDefinition[] = [
     path: ["URI"],
     type: "text",
     placeholder: "http://host:port",
-    required: true,
     validate: (value, context) => {
       const uri = String(value ?? "").trim();
       const managed = Boolean(getValue(context.section ?? {}, ["Managed"]));
@@ -716,7 +720,6 @@ const ARR_GENERAL_FIELDS: FieldDefinition[] = [
     path: ["APIKey"],
     type: "password",
     secure: true,
-    required: true,
     validate: (value, context) => {
       const apiKey = String(value ?? "").trim();
       const managed = Boolean(getValue(context.section ?? {}, ["Managed"]));
@@ -733,8 +736,11 @@ const ARR_GENERAL_FIELDS: FieldDefinition[] = [
     label: "Category",
     path: ["Category"],
     type: "text",
-    required: true,
-    validate: (value) => {
+    validate: (value, context) => {
+      const managed = Boolean(getValue(context.section ?? {}, ["Managed"]));
+      if (!managed) {
+        return undefined;
+      }
       if (!String(value ?? "").trim()) {
         return "Category is required.";
       }
@@ -754,7 +760,16 @@ const ARR_GENERAL_FIELDS: FieldDefinition[] = [
     path: ["importMode"],
     type: "select",
     options: IMPORT_MODE_OPTIONS,
-    required: true,
+    validate: (value, context) => {
+      const managed = Boolean(getValue(context.section ?? {}, ["Managed"]));
+      if (!managed) {
+        return undefined;
+      }
+      if (isEmptyValue(value)) {
+        return "Import Mode is required.";
+      }
+      return undefined;
+    },
   },
   {
     label: "RSS Sync Timer",
@@ -1490,35 +1505,265 @@ function validateFieldGroup(
   }
 }
 
-function validateFormState(formState: ConfigDocument | null): ValidationError[] {
+function isManagedArrSection(section: ConfigDocument | null): boolean {
+  return Boolean(getValue(section, ["Managed"]));
+}
+
+function isEnabledQbitSection(section: ConfigDocument | null): boolean {
+  return !getValue(section, ["Disabled"]);
+}
+
+function validateSection(
+  formState: ConfigDocument | null,
+  sectionKey: string
+): ValidationError[] {
+  if (!formState) return [];
+  const value = formState[sectionKey];
+  if (!value || typeof value !== "object") {
+    return [];
+  }
+  const section = value as ConfigDocument;
+  const errors: ValidationError[] = [];
+  const sectionContext: ValidationContext = { root: formState, section, sectionKey };
+
+  if (QBIT_SECTION_REGEX.test(sectionKey)) {
+    if (!isEnabledQbitSection(section)) {
+      return [];
+    }
+    validateFieldGroup(errors, QBIT_FIELDS, section, [sectionKey], sectionContext);
+    return errors;
+  }
+
+  if (SERVARR_SECTION_REGEX.test(sectionKey)) {
+    if (!isManagedArrSection(section)) {
+      return [];
+    }
+    const fieldSets = getArrFieldSets(sectionKey);
+    validateFieldGroup(errors, fieldSets.generalFields, section, [sectionKey], sectionContext);
+    validateFieldGroup(errors, fieldSets.entryFields, section, [sectionKey], sectionContext);
+    validateFieldGroup(errors, fieldSets.entryOmbiFields, section, [sectionKey], sectionContext);
+    validateFieldGroup(errors, fieldSets.entryOverseerrFields, section, [sectionKey], sectionContext);
+    validateFieldGroup(errors, fieldSets.torrentFields, section, [sectionKey], sectionContext);
+    validateFieldGroup(errors, fieldSets.seedingFields, section, [sectionKey], sectionContext);
+    return errors;
+  }
+
+  if (sectionKey === "Settings") {
+    validateFieldGroup(errors, SETTINGS_FIELDS, formState, [], { root: formState });
+  } else if (sectionKey === "WebUI") {
+    validateFieldGroup(errors, WEB_SETTINGS_FIELDS, formState, [], { root: formState });
+  } else if (sectionKey === "Authentication") {
+    validateFieldGroup(errors, AUTH_SETTINGS_FIELDS, formState, [], { root: formState });
+  }
+
+  return errors;
+}
+
+function sectionHasCategoryChanges(
+  sectionKey: string,
+  formState: ConfigDocument,
+  originalConfig: ConfigDocument | null
+): boolean {
+  const categoryPath = `${sectionKey}.Category`;
+  const flattenedOriginal = flatten(originalConfig ?? {});
+  const flattenedCurrent = flatten(formState);
+  return !equal(flattenedCurrent[categoryPath], flattenedOriginal[categoryPath]);
+}
+
+function validateSectionsForSave(
+  formState: ConfigDocument | null,
+  sectionKeys: string[],
+  originalConfig: ConfigDocument | null,
+  includeCategoryCrossCheck: boolean
+): ValidationError[] {
   if (!formState) return [];
   const errors: ValidationError[] = [];
-  const rootContext: ValidationContext = { root: formState };
-  validateFieldGroup(errors, SETTINGS_FIELDS, formState, [], rootContext);
-  validateFieldGroup(errors, WEB_SETTINGS_FIELDS, formState, [], rootContext);
-  validateFieldGroup(errors, AUTH_SETTINGS_FIELDS, formState, [], rootContext);
-
-  for (const [key, value] of Object.entries(formState)) {
-    if (QBIT_SECTION_REGEX.test(key) && value && typeof value === "object") {
-      const section = value as ConfigDocument;
-      const sectionContext: ValidationContext = { root: formState, section, sectionKey: key };
-      validateFieldGroup(errors, QBIT_FIELDS, section, [key], sectionContext);
-    } else if (SERVARR_SECTION_REGEX.test(key) && value && typeof value === "object") {
-      const section = value as ConfigDocument;
-      const sectionContext: ValidationContext = { root: formState, section, sectionKey: key };
-      const fieldSets = getArrFieldSets(key);
-      validateFieldGroup(errors, fieldSets.generalFields, section, [key], sectionContext);
-      validateFieldGroup(errors, fieldSets.entryFields, section, [key], sectionContext);
-      validateFieldGroup(errors, fieldSets.entryOmbiFields, section, [key], sectionContext);
-      validateFieldGroup(errors, fieldSets.entryOverseerrFields, section, [key], sectionContext);
-      validateFieldGroup(errors, fieldSets.torrentFields, section, [key], sectionContext);
-      validateFieldGroup(errors, fieldSets.seedingFields, section, [key], sectionContext);
+  for (const sectionKey of sectionKeys) {
+    errors.push(...validateSection(formState, sectionKey));
+  }
+  if (includeCategoryCrossCheck) {
+    for (const issue of getCategoryCrossSectionIssues(formState)) {
+      errors.push(issue);
+    }
+  } else {
+    const categoryTouched = sectionKeys.some((key) =>
+      sectionHasCategoryChanges(key, formState, originalConfig)
+    );
+    if (categoryTouched) {
+      for (const issue of getCategoryCrossSectionIssues(formState)) {
+        errors.push(issue);
+      }
     }
   }
-  for (const issue of getCategoryCrossSectionIssues(formState)) {
-    errors.push(issue);
-  }
   return errors;
+}
+
+function getChangedSectionKeys(
+  formState: ConfigDocument,
+  originalConfig: ConfigDocument | null,
+  pendingRenames: Map<string, string>
+): string[] {
+  const flattenedOriginal = flatten(originalConfig ?? {});
+  const flattenedCurrent = flatten(formState);
+  const sections = new Set<string>();
+
+  for (const [key, value] of Object.entries(flattenedCurrent)) {
+    if (!equal(value, flattenedOriginal[key])) {
+      sections.add(key.split(".")[0] ?? key);
+    }
+  }
+  for (const key of Object.keys(flattenedOriginal)) {
+    if (!(key in flattenedCurrent)) {
+      sections.add(key.split(".")[0] ?? key);
+    }
+  }
+  for (const [oldName] of pendingRenames) {
+    sections.add(oldName);
+    const newName = pendingRenames.get(oldName);
+    if (newName) {
+      sections.add(newName);
+    }
+  }
+  for (const [key, value] of Object.entries(originalConfig ?? {})) {
+    if (
+      !(key in formState) &&
+      SERVARR_SECTION_REGEX.test(key) &&
+      value &&
+      typeof value === "object"
+    ) {
+      sections.add(key);
+    }
+  }
+
+  return [...sections];
+}
+
+function buildSectionChanges(
+  formState: ConfigDocument,
+  originalConfig: ConfigDocument | null,
+  sectionKey: string,
+  pendingRenames: Map<string, string>
+): Record<string, unknown> {
+  const flattenedOriginal = flatten(originalConfig ?? {});
+  const flattenedCurrent = flatten(formState);
+  const changes: Record<string, unknown> = {};
+  const prefix = `${sectionKey}.`;
+
+  for (const [key, value] of Object.entries(flattenedCurrent)) {
+    if (key !== sectionKey && !key.startsWith(prefix)) {
+      continue;
+    }
+    const originalValue = flattenedOriginal[key];
+    if (!equal(value, originalValue)) {
+      changes[key] = value;
+    }
+  }
+
+  for (const key of Object.keys(flattenedOriginal)) {
+    if ((key === sectionKey || key.startsWith(prefix)) && !(key in flattenedCurrent)) {
+      changes[key] = null;
+    }
+  }
+
+  for (const [oldName, newName] of pendingRenames) {
+    if (oldName !== sectionKey && newName !== sectionKey) {
+      continue;
+    }
+    for (const key of Object.keys(flattenedOriginal)) {
+      if (key === oldName || key.startsWith(`${oldName}.`)) {
+        if (!(key in changes)) {
+          changes[key] = null;
+        }
+      }
+    }
+  }
+
+  if (
+    !(sectionKey in formState) &&
+    SERVARR_SECTION_REGEX.test(sectionKey) &&
+    sectionKey in (originalConfig ?? {})
+  ) {
+    changes[sectionKey] = null;
+  }
+
+  return changes;
+}
+
+function prunePendingRenames(
+  pendingRenames: Map<string, string>,
+  savedSectionKeys: Iterable<string> | "all"
+): Map<string, string> {
+  if (savedSectionKeys === "all") {
+    return new Map();
+  }
+  const saved = new Set(savedSectionKeys);
+  const next = new Map(pendingRenames);
+  for (const [oldName, newName] of pendingRenames) {
+    if (saved.has(oldName) || saved.has(newName)) {
+      next.delete(oldName);
+    }
+  }
+  return next;
+}
+
+function sectionKeysFromChanges(changes: Record<string, unknown>): string[] {
+  const sections = new Set<string>();
+  for (const key of Object.keys(changes)) {
+    sections.add(key.split(".")[0] ?? key);
+  }
+  return [...sections];
+}
+
+function buildAllChanges(
+  formState: ConfigDocument,
+  originalConfig: ConfigDocument | null,
+  pendingRenames: Map<string, string>
+): Record<string, unknown> {
+  const flattenedOriginal = flatten(originalConfig ?? {});
+  const flattenedCurrent = flatten(formState);
+  const changes: Record<string, unknown> = {};
+
+  for (const [key, value] of Object.entries(flattenedCurrent)) {
+    const originalValue = flattenedOriginal[key];
+    if (!equal(value, originalValue)) {
+      changes[key] = value;
+    }
+  }
+  for (const key of Object.keys(flattenedOriginal)) {
+    if (!(key in flattenedCurrent)) {
+      changes[key] = null;
+    }
+  }
+  for (const [key, value] of Object.entries(originalConfig ?? {})) {
+    if (
+      !(key in formState) &&
+      SERVARR_SECTION_REGEX.test(key) &&
+      value &&
+      typeof value === "object"
+    ) {
+      changes[key] = null;
+    }
+  }
+  for (const [oldName] of pendingRenames) {
+    for (const key of Object.keys(flattenedOriginal)) {
+      if (key === oldName || key.startsWith(`${oldName}.`)) {
+        if (!(key in changes)) {
+          changes[key] = null;
+        }
+      }
+    }
+  }
+
+  return changes;
+}
+
+function formatValidationErrors(validationErrors: ValidationError[]): string {
+  const formatted = validationErrors
+    .map((error) => `${error.path.join(".")}: ${error.message}`)
+    .join("\n");
+  return validationErrors.length === 1
+    ? formatted
+    : `Please resolve the following issues:\n${formatted}`;
 }
 
 // Note: cloneConfig is no longer needed - using immer's produce for immutable updates
@@ -1688,6 +1933,7 @@ export function ConfigView(props?: ConfigViewProps): JSX.Element {
   const [formState, setFormState] = useState<ConfigDocument | null>(null);
   const [loading, setLoading] = useState(false);
   const [saving, setSaving] = useState(false);
+  const [savingSection, setSavingSection] = useState<string | null>(null);
   const [pendingRenames, setPendingRenames] = useState<Map<string, string>>(new Map());
 
   const loadConfig = useCallback(async () => {
@@ -1877,6 +2123,14 @@ export function ConfigView(props?: ConfigViewProps): JSX.Element {
     if (!anyModalOpen) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
+        const target = event.target;
+        if (
+          target instanceof HTMLInputElement ||
+          target instanceof HTMLTextAreaElement ||
+          target instanceof HTMLSelectElement
+        ) {
+          return;
+        }
         setActiveArrKey(null);
         setActiveQbitKey(null);
         setSettingsOpen(false);
@@ -2081,68 +2335,13 @@ export function ConfigView(props?: ConfigViewProps): JSX.Element {
     [formState, push, activeQbitKey]
   );
 
-  const handleSubmit = useCallback(async () => {
-    if (!formState) return;
-    setSaving(true);
-    try {
-      const validationErrors = validateFormState(formState);
-      if (validationErrors.length) {
-        const formatted = validationErrors
-          .map((error) => `${error.path.join(".")}: ${error.message}`)
-          .join("\n");
-        const message =
-          validationErrors.length === 1
-            ? formatted
-            : `Please resolve the following issues:\n${formatted}`;
-        push(message, "error");
-        setSaving(false);
-        return;
-      }
-      const flattenedOriginal = flatten(originalConfig ?? {});
-      const flattenedCurrent = flatten(formState);
-      const changes: Record<string, unknown> = {};
-      for (const [key, value] of Object.entries(flattenedCurrent)) {
-        const originalValue = flattenedOriginal[key];
-        // Use fast-deep-equal for accurate comparison
-        if (!equal(value, originalValue)) {
-          changes[key] = value;
-        }
-      }
-      for (const key of Object.keys(flattenedOriginal)) {
-        if (!(key in flattenedCurrent)) {
-          changes[key] = null;
-        }
-      }
-      // Add top-level tombstones for removed Arr sections to ensure full section deletion.
-      for (const [key, value] of Object.entries(originalConfig ?? {})) {
-        if (
-          !(key in formState) &&
-          SERVARR_SECTION_REGEX.test(key) &&
-          value &&
-          typeof value === "object"
-        ) {
-          changes[key] = null;
-        }
-      }
-      // Explicitly mark all keys under renamed sections for deletion
-      for (const [oldName] of pendingRenames) {
-        for (const key of Object.keys(flattenedOriginal)) {
-          if (key === oldName || key.startsWith(`${oldName}.`)) {
-            // Mark for deletion if not already tracked
-            if (!(key in changes)) {
-              changes[key] = null;
-            }
-          }
-        }
-      }
-      if (Object.keys(changes).length === 0) {
-        push("No changes detected", "info");
-        setSaving(false);
-        return;
-      }
-      const { configReloaded, reloadType, affectedInstances } = await updateConfig({ changes });
-
-      // Build appropriate success message
+  const applyConfigSaveResult = useCallback(
+    async (
+      configReloaded: boolean,
+      reloadType: string,
+      affectedInstances: string[] | undefined,
+      savedSectionKeys: Iterable<string> | "all"
+    ) => {
       let message = "Configuration saved";
       if (reloadType === "full") {
         message += " • All instances reloaded";
@@ -2157,32 +2356,115 @@ export function ConfigView(props?: ConfigViewProps): JSX.Element {
       }
       push(message, "success");
 
-      // Only clear browser cache if backend reloaded (non-frontend-only changes)
-      if (configReloaded && 'caches' in window) {
+      if (configReloaded && "caches" in window) {
         try {
           const cacheNames = await caches.keys();
-          await Promise.all(
-            cacheNames.map(cacheName => caches.delete(cacheName))
-          );
+          await Promise.all(cacheNames.map((cacheName) => caches.delete(cacheName)));
         } catch {
           // cache clear failed, non-critical
         }
       }
 
       await loadConfig();
-      // Clear pending renames after successful save and reload
-      setPendingRenames(new Map());
+      setPendingRenames((prev) => prunePendingRenames(prev, savedSectionKeys));
+    },
+    [loadConfig, push]
+  );
+
+  const saveSection = useCallback(
+    async (sectionKey: string): Promise<boolean> => {
+      if (!formState) return false;
+      setSavingSection(sectionKey);
+      try {
+        const validationErrors = validateSectionsForSave(
+          formState,
+          [sectionKey],
+          originalConfig,
+          false
+        );
+        if (validationErrors.length) {
+          push(formatValidationErrors(validationErrors), "error");
+          return false;
+        }
+
+        const changes = buildSectionChanges(
+          formState,
+          originalConfig,
+          sectionKey,
+          pendingRenames
+        );
+        if (Object.keys(changes).length === 0) {
+          push(`No changes detected for ${sectionKey}`, "info");
+          return false;
+        }
+
+        const { configReloaded, reloadType, affectedInstances } = await updateConfig({ changes });
+        const savedKeys = sectionKeysFromChanges(changes);
+        for (const [oldName, newName] of pendingRenames) {
+          if (oldName === sectionKey || newName === sectionKey) {
+            savedKeys.push(oldName, newName);
+          }
+        }
+        await applyConfigSaveResult(
+          configReloaded,
+          reloadType,
+          affectedInstances,
+          savedKeys
+        );
+        return true;
+      } catch (error) {
+        push(
+          error instanceof Error ? error.message : "Failed to update configuration",
+          "error"
+        );
+        return false;
+      } finally {
+        setSavingSection(null);
+      }
+    },
+    [formState, originalConfig, pendingRenames, push, applyConfigSaveResult]
+  );
+
+  const handleSubmit = useCallback(async () => {
+    if (!formState) return;
+    setSaving(true);
+    try {
+      const changedSections = getChangedSectionKeys(formState, originalConfig, pendingRenames);
+      const validationErrors = validateSectionsForSave(
+        formState,
+        changedSections,
+        originalConfig,
+        true
+      );
+      if (validationErrors.length) {
+        push(formatValidationErrors(validationErrors), "error");
+        setSaving(false);
+        return;
+      }
+
+      const changes = buildAllChanges(formState, originalConfig, pendingRenames);
+      if (Object.keys(changes).length === 0) {
+        push("No changes detected", "info");
+        setSaving(false);
+        return;
+      }
+
+      const { configReloaded, reloadType, affectedInstances } = await updateConfig({ changes });
+      await applyConfigSaveResult(
+        configReloaded,
+        reloadType,
+        affectedInstances,
+        "all"
+      );
     } catch (error) {
       push(
-        error instanceof Error
-          ? error.message
-          : "Failed to update configuration",
+        error instanceof Error ? error.message : "Failed to update configuration",
         "error"
       );
     } finally {
       setSaving(false);
     }
-  }, [formState, originalConfig, loadConfig, pendingRenames, push]);
+  }, [formState, originalConfig, pendingRenames, push, applyConfigSaveResult]);
 
   if (loading || !formState) {
     return (
@@ -2273,6 +2555,15 @@ export function ConfigView(props?: ConfigViewProps): JSX.Element {
                             Delete
                           </button>
                           <button
+                            className="btn secondary"
+                            type="button"
+                            disabled={savingSection === key || saving}
+                            onClick={() => void saveSection(key)}
+                          >
+                            <IconImage src={SaveIcon} />
+                            {savingSection === key ? "Saving..." : "Save"}
+                          </button>
+                          <button
                             className="btn primary"
                             type="button"
                             onClick={() => setActiveQbitKey(key)}
@@ -2347,6 +2638,15 @@ export function ConfigView(props?: ConfigViewProps): JSX.Element {
                                   </button>
                                 ) : null}
                                 <button
+                                  className="btn secondary"
+                                  type="button"
+                                  disabled={savingSection === key || saving}
+                                  onClick={() => void saveSection(key)}
+                                >
+                                  <IconImage src={SaveIcon} />
+                                  {savingSection === key ? "Saving..." : "Save"}
+                                </button>
+                                <button
                                   className="btn primary"
                                   type="button"
                                   onClick={() => setActiveArrKey(key)}
@@ -2384,6 +2684,7 @@ export function ConfigView(props?: ConfigViewProps): JSX.Element {
           onChange={handleFieldChange}
           onRename={handleRenameSection}
           onClose={() => setActiveArrKey(null)}
+          onSave={() => saveSection(activeArrKey)}
           overlapWarnings={categoryOverlapWarnings}
         />
       ) : null}
@@ -2429,6 +2730,7 @@ export function ConfigView(props?: ConfigViewProps): JSX.Element {
           onChange={handleFieldChange}
           onRename={handleRenameQbitSection}
           onClose={() => setActiveQbitKey(null)}
+          onSave={() => saveSection(activeQbitKey)}
           onDelete={() => deleteQbitInstance(activeQbitKey)}
           overlapWarnings={categoryOverlapWarnings}
         />
@@ -2543,58 +2845,101 @@ function DurationInput({
   const display = parseDurationDisplay(value, nativeUnit, fallback);
   const [num, setNum] = useState(display.number);
   const [unit, setUnit] = useState<DurationUnit>(display.unit);
-  // rawInput tracks the user's in-progress text; null when not actively editing
   const [rawInput, setRawInput] = useState<string | null>(null);
   const isEditing = useRef(false);
+  const unitDirty = useRef(false);
 
   useEffect(() => {
     if (!isEditing.current) {
       const d = parseDurationDisplay(value, nativeUnit, fallback);
       queueMicrotask(() => {
         setNum(d.number);
-        setUnit(d.unit);
+        if (!unitDirty.current) {
+          setUnit(d.unit);
+        }
       });
     }
   }, [value, nativeUnit, fallback]);
 
   const handleNumChange = (raw: string) => {
-    // Only allow numeric characters, optional leading minus, optional decimal
     if (raw !== "" && !NUMERIC_INPUT_RE.test(raw)) return;
     setRawInput(raw);
-    // Don't commit empty or incomplete strings — wait until blur
     if (raw === "" || raw === "-") return;
     const n = Number(raw);
     if (!Number.isFinite(n)) return;
     setNum(n);
+    unitDirty.current = false;
     const out = durationDisplayToValue(n, unit, nativeUnit, allowNegative);
     onChange(out);
   };
 
   const handleUnitChange = (newUnit: DurationUnit) => {
     setUnit(newUnit);
-    const out = durationDisplayToValue(num, newUnit, nativeUnit, allowNegative);
+    unitDirty.current = true;
+    if (rawInput === "" || rawInput === "-") {
+      return;
+    }
+    const effectiveNum = rawInput !== null ? Number(rawInput) : num;
+    if (!Number.isFinite(effectiveNum)) {
+      return;
+    }
+    setNum(effectiveNum);
+    unitDirty.current = false;
+    const out = durationDisplayToValue(effectiveNum, newUnit, nativeUnit, allowNegative);
     onChange(out);
   };
 
   const handleFocus = () => {
     isEditing.current = true;
-    // When field shows "Disabled" (-1), clear to empty so user can type a value
+    unitDirty.current = false;
     setRawInput(num === -1 && allowNegative ? "" : String(num));
   };
 
   const handleBlur = () => {
     isEditing.current = false;
+    const pendingRaw = rawInput;
     setRawInput(null);
-    // Revert to the last externally-committed value (reverts empty/invalid edits)
+
+    if (pendingRaw === "" && allowNegative) {
+      unitDirty.current = false;
+      setNum(-1);
+      onChange(-1);
+      return;
+    }
+
+    if (pendingRaw === "" || pendingRaw === "-") {
+      const d = parseDurationDisplay(value, nativeUnit, fallback);
+      setNum(d.number);
+      if (!unitDirty.current) {
+        setUnit(d.unit);
+      }
+      unitDirty.current = false;
+      return;
+    }
+
+    unitDirty.current = false;
     const d = parseDurationDisplay(value, nativeUnit, fallback);
     setNum(d.number);
     setUnit(d.unit);
   };
 
-  // While editing show the raw string; otherwise show the formatted display value
-  const displayVal = rawInput !== null
-    ? rawInput
-    : (num === -1 && allowNegative ? "Disabled" : String(num));
+  const handleSetDisabled = () => {
+    if (!allowNegative) return;
+    isEditing.current = false;
+    unitDirty.current = false;
+    setRawInput(null);
+    setNum(-1);
+    setUnit("s");
+    onChange(-1);
+  };
+
+  const isDisabledValue = num === -1 && allowNegative && rawInput === null;
+  const displayVal =
+    rawInput !== null ? rawInput : isDisabledValue ? "" : String(num);
+  const inputPlaceholder =
+    allowNegative && (isDisabledValue || rawInput === "")
+      ? "Disabled"
+      : placeholder;
 
   return (
     <div className="duration-input">
@@ -2604,7 +2949,7 @@ function DurationInput({
         onFocus={handleFocus}
         onBlur={handleBlur}
         onChange={(e) => handleNumChange(e.target.value)}
-        placeholder={placeholder}
+        placeholder={inputPlaceholder}
       />
       <select
         value={unit}
@@ -2617,6 +2962,15 @@ function DurationInput({
           </option>
         ))}
       </select>
+      {allowNegative ? (
+        <button
+          type="button"
+          className="btn small ghost duration-input__disabled"
+          onClick={handleSetDisabled}
+        >
+          Use disabled
+        </button>
+      ) : null}
     </div>
   );
 }
@@ -3295,12 +3649,17 @@ function ArrTorrentSummary({
   );
 }
 
+function ConfigModalPortal({ children }: { children: React.ReactNode }): JSX.Element {
+  return createPortal(children, document.body);
+}
+
 interface ArrInstanceModalProps {
   keyName: string;
   state: ConfigDocument | ConfigDocument[keyof ConfigDocument] | null;
   onChange: (path: string[], def: FieldDefinition, value: unknown) => void;
   onRename: (oldName: string, newName: string) => void;
   onClose: () => void;
+  onSave: () => Promise<boolean>;
   overlapWarnings: string[];
 }
 
@@ -3310,6 +3669,7 @@ function ArrInstanceModal({
   onChange,
   onRename,
   onClose,
+  onSave,
   overlapWarnings,
 }: ArrInstanceModalProps): JSX.Element {
   const { generalFields, entryFields, entryOmbiFields, entryOverseerrFields, torrentFields, seedingFields, trackerFields } =
@@ -3325,6 +3685,7 @@ function ArrInstanceModal({
   const [qualityProfiles, setQualityProfiles] = useState<
     Array<{ id: number; name: string }>
   >([]);
+  const [savingModal, setSavingModal] = useState(false);
 
   // Helper to get value from state
   const getValue = (path: string[]): unknown => {
@@ -3411,43 +3772,49 @@ function ArrInstanceModal({
     }
   }
 
-  // Handle save with connection test
   const handleSave = async () => {
-    const uri = getValue(["URI"]) as string;
-    const apiKey = getValue(["APIKey"]) as string;
+    if (savingModal) return;
+    setSavingModal(true);
+    try {
+      const uri = getValue(["URI"]) as string;
+      const apiKey = getValue(["APIKey"]) as string;
+      const managed = Boolean(getValue(["Managed"]));
 
-    // If credentials exist, test connection before saving
-    if (uri && apiKey) {
-      const success = await handleTestConnection(false);
-      if (success) {
-        push("Configuration saved successfully", "success");
+      if (managed && uri && apiKey) {
+        const success = await handleTestConnection(false);
+        if (!success) {
+          return;
+        }
+      }
+
+      const saved = await onSave();
+      if (saved) {
         onClose();
       }
-      // If unsuccessful, stay open so user can fix config
-    } else {
-      // No credentials to test, just close
-      onClose();
+    } finally {
+      setSavingModal(false);
     }
   };
 
   return (
-    <div className="modal-backdrop" role="presentation">
-      <div
-        className="modal"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="arr-instance-modal-title"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="modal-header">
-          <h2 id="arr-instance-modal-title">
-            Configure <code>{keyName}</code>
-          </h2>
-          <button className="btn ghost" type="button" onClick={onClose}>
-            <IconImage src={CloseIcon} />
-            Close
-          </button>
-        </div>
+    <ConfigModalPortal>
+      <div className="modal-backdrop" role="presentation">
+        <div
+          className="modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="arr-instance-modal-title"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="modal-header">
+            <h2 id="arr-instance-modal-title">
+              Configure <code>{keyName}</code>
+            </h2>
+            <button className="btn ghost" type="button" onClick={safeClick(onClose)}>
+              <IconImage src={CloseIcon} />
+              Close
+            </button>
+          </div>
         <div className="modal-body">
           <ArrTorrentSummary state={state} />
           <CategoryOverlapAlert messages={overlapWarnings} />
@@ -3572,13 +3939,19 @@ function ArrInstanceModal({
               "Test"
             )}
           </button>
-          <button className="btn primary" type="button" onClick={handleSave}>
+          <button
+            className="btn primary"
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={savingModal || testState.testing}
+          >
             <IconImage src={SaveIcon} />
-            Save
+            {savingModal ? "Saving..." : "Save"}
           </button>
         </div>
       </div>
     </div>
+    </ConfigModalPortal>
   );
 }
 
@@ -3607,6 +3980,7 @@ interface QbitInstanceModalProps {
   onChange: (path: string[], def: FieldDefinition, value: unknown) => void;
   onRename: (oldName: string, newName: string) => void;
   onClose: () => void;
+  onSave: () => Promise<boolean>;
   onDelete?: () => void;
   overlapWarnings: string[];
 }
@@ -3617,27 +3991,44 @@ function QbitInstanceModal({
   onChange,
   onRename,
   onClose,
+  onSave,
   onDelete,
   overlapWarnings,
 }: QbitInstanceModalProps): JSX.Element {
+  const [savingModal, setSavingModal] = useState(false);
+
+  const handleDone = async () => {
+    if (savingModal) return;
+    setSavingModal(true);
+    try {
+      const saved = await onSave();
+      if (saved) {
+        onClose();
+      }
+    } finally {
+      setSavingModal(false);
+    }
+  };
+
   return (
-    <div className="modal-backdrop" role="presentation">
-      <div
-        className="modal"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="qbit-instance-modal-title"
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="modal-header">
-          <h2 id="qbit-instance-modal-title">
-            Configure <code>{keyName}</code>
-          </h2>
-          <button className="btn ghost" type="button" onClick={onClose}>
-            <IconImage src={CloseIcon} />
-            Close
-          </button>
-        </div>
+    <ConfigModalPortal>
+      <div className="modal-backdrop" role="presentation">
+        <div
+          className="modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="qbit-instance-modal-title"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <div className="modal-header">
+            <h2 id="qbit-instance-modal-title">
+              Configure <code>{keyName}</code>
+            </h2>
+            <button className="btn ghost" type="button" onClick={safeClick(onClose)}>
+              <IconImage src={CloseIcon} />
+              Close
+            </button>
+          </div>
         <div className="modal-body">
           <QbitTorrentSummary state={state} />
           <CategoryOverlapAlert messages={overlapWarnings} />
@@ -3666,22 +4057,28 @@ function QbitInstanceModal({
             <button
               className="btn danger"
               type="button"
-              onClick={() => {
+              onClick={safeClick(() => {
                 onDelete();
                 onClose();
-              }}
+              })}
             >
               <IconImage src={DeleteIcon} />
               Delete
             </button>
           )}
-          <button className="btn primary" type="button" onClick={onClose}>
+          <button
+            className="btn primary"
+            type="button"
+            onClick={() => void handleDone()}
+            disabled={savingModal}
+          >
             <IconImage src={SaveIcon} />
-            Done
+            {savingModal ? "Saving..." : "Save"}
           </button>
         </div>
       </div>
     </div>
+    </ConfigModalPortal>
   );
 }
 
@@ -3710,21 +4107,22 @@ function SimpleConfigModal({
 
   if (!state) return null;
   return (
-    <div className="modal-backdrop" role="presentation">
-      <div
-        className="modal"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby={`${title}-modal-title`}
-        onClick={(event) => event.stopPropagation()}
-      >
-        <div className="modal-header">
-          <h2 id={`${title}-modal-title`}>{title}</h2>
-          <button className="btn ghost" type="button" onClick={onClose}>
-            <IconImage src={CloseIcon} />
-            Close
-          </button>
-        </div>
+    <ConfigModalPortal>
+      <div className="modal-backdrop" role="presentation">
+        <div
+          className="modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby={`${title}-modal-title`}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="modal-header">
+            <h2 id={`${title}-modal-title`}>{title}</h2>
+            <button className="btn ghost" type="button" onClick={safeClick(onClose)}>
+              <IconImage src={CloseIcon} />
+              Close
+            </button>
+          </div>
         <div className="modal-body">
           <FieldGroup
             title={null}
@@ -3803,13 +4201,14 @@ function SimpleConfigModal({
           )}
         </div>
         <div className="modal-footer">
-          <button className="btn primary" type="button" onClick={onClose}>
+          <button className="btn primary" type="button" onClick={safeClick(onClose)}>
             <IconImage src={SaveIcon} />
             Done
           </button>
         </div>
       </div>
     </div>
+    </ConfigModalPortal>
   );
 }
 
@@ -3855,22 +4254,23 @@ function SetPasswordModal({ onClose }: SetPasswordModalProps): JSX.Element {
   };
 
   return (
-    <div className="modal-backdrop" role="presentation">
-      <div
-        className="modal"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="set-password-modal-title"
-        onClick={(e) => e.stopPropagation()}
-        style={{ maxWidth: 480 }}
-      >
-        <div className="modal-header">
-          <h2 id="set-password-modal-title">Set Password</h2>
-          <button className="btn ghost" type="button" onClick={onClose}>
-            <IconImage src={CloseIcon} />
-            Close
-          </button>
-        </div>
+    <ConfigModalPortal>
+      <div className="modal-backdrop" role="presentation">
+        <div
+          className="modal"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="set-password-modal-title"
+          onClick={(e) => e.stopPropagation()}
+          style={{ maxWidth: 480 }}
+        >
+          <div className="modal-header">
+            <h2 id="set-password-modal-title">Set Password</h2>
+            <button className="btn ghost" type="button" onClick={safeClick(onClose)}>
+              <IconImage src={CloseIcon} />
+              Close
+            </button>
+          </div>
         <div className="modal-body">
           {success ? (
             <div style={{ padding: "1rem 0", color: "var(--success)" }}>
@@ -3931,7 +4331,12 @@ function SetPasswordModal({ onClose }: SetPasswordModalProps): JSX.Element {
               </div>
               {error && <div style={{ color: "var(--danger)", fontSize: "0.875rem" }}>{error}</div>}
               <div style={{ display: "flex", gap: "0.5rem", justifyContent: "flex-end" }}>
-                <button className="btn ghost" type="button" onClick={onClose} disabled={submitting}>
+                <button
+                  className="btn ghost"
+                  type="button"
+                  onClick={safeClick(onClose)}
+                  disabled={submitting}
+                >
                   Cancel
                 </button>
                 <button className="btn primary" type="submit" disabled={submitting}>
@@ -3943,12 +4348,13 @@ function SetPasswordModal({ onClose }: SetPasswordModalProps): JSX.Element {
         </div>
         {success && (
           <div className="modal-footer">
-            <button className="btn primary" type="button" onClick={onClose}>
+            <button className="btn primary" type="button" onClick={safeClick(onClose)}>
               Close
             </button>
           </div>
         )}
       </div>
     </div>
+    </ConfigModalPortal>
   );
 }

--- a/webui/src/pages/ConfigView.tsx
+++ b/webui/src/pages/ConfigView.tsx
@@ -387,6 +387,30 @@ const WEB_SETTINGS_FIELDS: FieldDefinition[] = [
     type: "checkbox",
     description: "Set when the WebUI is reached over HTTPS (e.g. reverse proxy). Enables Secure cookies.",
   },
+  {
+    label: "Url Base",
+    path: ["WebUI", "UrlBase"],
+    type: "text",
+    placeholder: "/qbitrr",
+    description:
+      "Public path prefix when behind a reverse proxy (e.g. /qbitrr). Leave empty for site root.",
+    validate: (value) => {
+      const raw = String(value ?? "").trim();
+      if (!raw) {
+        return undefined;
+      }
+      if (!raw.startsWith("/")) {
+        return "UrlBase must start with / (e.g. /qbitrr).";
+      }
+      if (raw.endsWith("/")) {
+        return "UrlBase must not end with a trailing slash.";
+      }
+      if (raw.includes("//")) {
+        return "UrlBase is invalid.";
+      }
+      return undefined;
+    },
+  },
 ];
 
 const AUTH_SETTINGS_FIELDS: FieldDefinition[] = [

--- a/webui/src/pages/LoginPage.tsx
+++ b/webui/src/pages/LoginPage.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { login, setPassword, AuthError } from "../api/client";
+import { webPath } from "../api/urlBase";
 
 interface LoginPageProps {
   onSuccess: () => void;
@@ -126,7 +127,7 @@ export function LoginPage({ onSuccess, localAuthEnabled, oidcEnabled, setupRequi
               <div className="oidc-section">
                 {localAuthEnabled && <div className="login-divider">or</div>}
                 <a
-                  href="/web/auth/oidc/challenge"
+                  href={webPath("/web/auth/oidc/challenge")}
                   className="btn ghost login-oidc-btn"
                 >
                   Sign in with SSO

--- a/webui/src/pages/arrCatalog/useAggregateCatalogLoader.ts
+++ b/webui/src/pages/arrCatalog/useAggregateCatalogLoader.ts
@@ -133,11 +133,13 @@ export function useAggregateCatalogLoader<
   );
   const { snapshot, store } = useRowsStore<TAggRow>(rowsStoreOpts as never);
 
+  const filtersKey = useMemo(() => JSON.stringify(filters), [filters]);
+
   const filteredRows = useMemo<ReadonlyArray<TAggRow>>(() => {
     const filterFn = adapter.filterRows;
     if (!filterFn) return rows;
-    return filterFn(rows, filtersRef.current, debouncedSearch);
-  }, [rows, debouncedSearch, adapter]);
+    return filterFn(rows, filters, debouncedSearch);
+  }, [rows, debouncedSearch, adapter, filtersKey, filters]);
 
   const sortedRows = useMemo<ReadonlyArray<TAggRow>>(() => {
     const sortFn = adapter.sortRows;
@@ -320,12 +322,13 @@ export function useAggregateCatalogLoader<
     [adapter, instances, dataSync.syncData, pushToast],
   );
 
-  // Trigger initial load when the user navigates to the aggregate view.
+  // Trigger load when entering aggregate view or when server-side filter params change.
   useEffect(() => {
     if (!active) return;
     if (selection !== "aggregate") return;
+    setPage(0);
     void loadAggregate();
-  }, [active, selection, loadAggregate]);
+  }, [active, selection, filtersKey, loadAggregate]);
 
   // Sync the aggregate filter with the global search whenever the user is on the
   // aggregate view.

--- a/webui/src/pages/arrCatalog/useInstancePagedFetch.ts
+++ b/webui/src/pages/arrCatalog/useInstancePagedFetch.ts
@@ -118,8 +118,11 @@ export function useInstancePagedFetch<
 
   const pagesRef = useRef<Record<number, ReadonlyArray<TInstRow>>>({});
   const keyRef = useRef<string>("");
+  const fetchGenRef = useRef(0);
   const filtersRef = useRef(filters);
   filtersRef.current = filters;
+  const selectionRef = useRef(selection);
+  selectionRef.current = selection;
   const prevSelectionRef = useRef<string | null>(selection);
   const sawNonEmptyRef = useRef(false);
   const stableEmptyStreakRef = useRef(0);
@@ -150,6 +153,7 @@ export function useInstancePagedFetch<
       options: { showLoading?: boolean } = {},
     ) => {
       const showLoading = options.showLoading ?? true;
+      const gen = ++fetchGenRef.current;
       if (showLoading) setLoading(true);
       try {
         const currentFilters = filtersRef.current;
@@ -183,6 +187,12 @@ export function useInstancePagedFetch<
           requestQuery,
           currentFilters,
         );
+        if (
+          gen !== fetchGenRef.current ||
+          selectionRef.current !== category
+        ) {
+          return;
+        }
         setLatestResponse(response);
         const extracted = adapter.extractPage(response);
         const resolvedPage = Math.max(
@@ -253,7 +263,9 @@ export function useInstancePagedFetch<
           "error",
         );
       } finally {
-        if (showLoading) setLoading(false);
+        if (showLoading && gen === fetchGenRef.current) {
+          setLoading(false);
+        }
       }
     },
     // `useDataSync` returns a new object each render; depend on stable callbacks only.

--- a/webui/src/styles.css
+++ b/webui/src/styles.css
@@ -218,6 +218,7 @@ body {
     transition: all 0.15s ease;
     position: relative;
     overflow: hidden;
+    user-select: none;
 }
 
 .nav button::before {
@@ -944,6 +945,13 @@ body {
     flex: 0 0 auto;
     min-width: 7.5em;
     width: auto;
+}
+.duration-input {
+    flex-wrap: wrap;
+}
+.duration-input__disabled {
+    flex-shrink: 0;
+    white-space: nowrap;
 }
 .field.mobile-instance-select {
     display: none;

--- a/webui/src/utils/arrThumbnailUrl.ts
+++ b/webui/src/utils/arrThumbnailUrl.ts
@@ -9,6 +9,8 @@
  * history. The thumbnail responses now use ``Cache-Control: private`` so shared caches do not
  * keep token-bearing bytes.
  */
+import { webPath } from "../api/urlBase";
+
 const TOKEN_KEYS = ["token", "webui-token", "webui_token"] as const;
 
 function resolveTokenFromStorage(): string | null {
@@ -40,7 +42,7 @@ export function radarrMovieThumbnailUrl(
 ): string {
   const c = encodeURIComponent(category);
   return withWebUiToken(
-    `/web/radarr/${c}/movie/${entryId}/thumbnail`
+    webPath(`/web/radarr/${c}/movie/${entryId}/thumbnail`)
   );
 }
 
@@ -50,7 +52,7 @@ export function sonarrSeriesThumbnailUrl(
 ): string {
   const c = encodeURIComponent(category);
   return withWebUiToken(
-    `/web/sonarr/${c}/series/${entryId}/thumbnail`
+    webPath(`/web/sonarr/${c}/series/${entryId}/thumbnail`)
   );
 }
 
@@ -60,6 +62,6 @@ export function lidarrArtistThumbnailUrl(
 ): string {
   const c = encodeURIComponent(category);
   return withWebUiToken(
-    `/web/lidarr/${c}/artist/${artistId}/thumbnail`
+    webPath(`/web/lidarr/${c}/artist/${artistId}/thumbnail`)
   );
 }

--- a/webui/src/utils/safeClick.ts
+++ b/webui/src/utils/safeClick.ts
@@ -1,0 +1,181 @@
+import { useCallback, useRef, type MouseEvent, type PointerEvent } from "react";
+
+const MOVE_THRESHOLD_PX = 5;
+
+let trackingInstalled = false;
+let pointerDownTarget: EventTarget | null = null;
+let pointerDownPoint: { x: number; y: number } | null = null;
+let pointerDragged = false;
+
+function hasActiveTextSelection(): boolean {
+  const selection = window.getSelection()?.toString().trim();
+  return Boolean(selection);
+}
+
+function movedBeyondThreshold(
+  startX: number,
+  startY: number,
+  endX: number,
+  endY: number
+): boolean {
+  return (
+    Math.abs(endX - startX) > MOVE_THRESHOLD_PX ||
+    Math.abs(endY - startY) > MOVE_THRESHOLD_PX
+  );
+}
+
+function resetPointerSession(): void {
+  pointerDownTarget = null;
+  pointerDownPoint = null;
+  pointerDragged = false;
+}
+
+/** Install document-level pointer tracking for safe click detection. Idempotent. */
+export function installSafeClickTracking(): void {
+  if (trackingInstalled || typeof document === "undefined") {
+    return;
+  }
+  trackingInstalled = true;
+
+  document.addEventListener(
+    "pointerdown",
+    (event) => {
+      pointerDownTarget = event.target;
+      pointerDownPoint = { x: event.clientX, y: event.clientY };
+      pointerDragged = false;
+    },
+    true
+  );
+
+  document.addEventListener(
+    "pointermove",
+    (event) => {
+      if (!pointerDownPoint) {
+        return;
+      }
+      if (
+        movedBeyondThreshold(
+          pointerDownPoint.x,
+          pointerDownPoint.y,
+          event.clientX,
+          event.clientY
+        )
+      ) {
+        pointerDragged = true;
+      }
+    },
+    true
+  );
+
+  document.addEventListener(
+    "click",
+    () => {
+      resetPointerSession();
+    },
+    true
+  );
+}
+
+/** Ignore clicks that follow text selection or pointer drag. */
+export function shouldIgnoreClick(event: MouseEvent | PointerEvent): boolean {
+  if (hasActiveTextSelection()) {
+    return true;
+  }
+  if (pointerDragged) {
+    return true;
+  }
+  if (pointerDownPoint) {
+    if (
+      movedBeyondThreshold(
+        pointerDownPoint.x,
+        pointerDownPoint.y,
+        event.clientX,
+        event.clientY
+      )
+    ) {
+      return true;
+    }
+  }
+  if (
+    pointerDownTarget instanceof Node &&
+    event.currentTarget instanceof Node &&
+    pointerDownTarget !== event.currentTarget &&
+    !event.currentTarget.contains(pointerDownTarget)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/** Wrap a click handler so selection/drag-induced clicks are ignored. */
+export function createSafeClickHandler(
+  handler: (event: MouseEvent<HTMLElement>) => void
+): (event: MouseEvent<HTMLElement>) => void {
+  installSafeClickTracking();
+  return (event) => {
+    if (shouldIgnoreClick(event)) {
+      return;
+    }
+    handler(event);
+  };
+}
+
+/** Wrap a zero-arg click handler (modal close, tab switch, etc.). */
+export function safeClick(handler: () => void): (event: MouseEvent<HTMLElement>) => void {
+  return createSafeClickHandler(() => {
+    handler();
+  });
+}
+
+/** Backdrop dismiss that only fires when pointer down+up both hit the backdrop. */
+export function useSafeBackdropClose(onClose: () => void): {
+  onPointerDown: (event: PointerEvent<HTMLDivElement>) => void;
+  onPointerUp: (event: PointerEvent<HTMLDivElement>) => void;
+} {
+  installSafeClickTracking();
+  const pointerDownOnBackdrop = useRef(false);
+  const startPoint = useRef<{ x: number; y: number } | null>(null);
+
+  const onPointerDown = useCallback((event: PointerEvent<HTMLDivElement>) => {
+    pointerDownOnBackdrop.current = event.target === event.currentTarget;
+    startPoint.current = pointerDownOnBackdrop.current
+      ? { x: event.clientX, y: event.clientY }
+      : null;
+  }, []);
+
+  const onPointerUp = useCallback(
+    (event: PointerEvent<HTMLDivElement>) => {
+      const onBackdrop =
+        pointerDownOnBackdrop.current && event.target === event.currentTarget;
+      pointerDownOnBackdrop.current = false;
+      if (!onBackdrop) {
+        startPoint.current = null;
+        return;
+      }
+      if (shouldIgnoreClick(event)) {
+        startPoint.current = null;
+        return;
+      }
+      if (startPoint.current) {
+        if (
+          movedBeyondThreshold(
+            startPoint.current.x,
+            startPoint.current.y,
+            event.clientX,
+            event.clientY
+          )
+        ) {
+          startPoint.current = null;
+          return;
+        }
+      }
+      startPoint.current = null;
+      onClose();
+    },
+    [onClose]
+  );
+
+  return { onPointerDown, onPointerUp };
+}
+
+installSafeClickTracking();

--- a/webui/vite.config.ts
+++ b/webui/vite.config.ts
@@ -11,6 +11,15 @@ export default defineConfig({
     fs: {
       allow: [resolve(__dirname, "..")],
     },
+    proxy: {
+      "/web": "http://127.0.0.1:6969",
+      "/api": "http://127.0.0.1:6969",
+      "/ui": "http://127.0.0.1:6969",
+      "/static": "http://127.0.0.1:6969",
+      "/sw.js": "http://127.0.0.1:6969",
+      "/login": "http://127.0.0.1:6969",
+      "/health": "http://127.0.0.1:6969",
+    },
   },
   build: {
     outDir: resolve(__dirname, "../qBitrr/static"),


### PR DESCRIPTION
## Summary
- Fixes unexpected Config UI behaviour reported in #422: accidental modal/tab closes after text selection, duration field usability, and all-or-nothing save validation
- Adds per-instance Save for each qBittorrent and Arr instance, with validation scoped to that instance only
- Introduces configurable WebUI `UrlBase` for reverse-proxy subpath deployments, wiring API/static paths through a shared `webPath()` helper

## Config editor UX (#422)
- **Safe clicks:** document-level pointer tracking ignores nav/modal clicks after text selection or cross-element drags (`safeClick.ts`)
- **Tab navigation:** keyboard shortcuts (`1`–`9`) now prompt when leaving Config with unsaved changes; nav buttons use `user-select: none`
- **Duration fields:** disabled values use placeholder instead of literal `"Disabled"` text; unit dropdown persists while editing; **Use disabled** button added
- **Per-instance save:** Save button on each qBit/Arr card and in instance modals; global **Save + Live Reload** validates only changed sections
- **Modals:** portaled to `document.body`; Escape skipped when focus is in an input; Arr modal backdrop uses safe dismiss

## UrlBase
- New `[WebUI] UrlBase` config option for serving the UI under a subpath (e.g. `/qbitrr`)
- Backend serves static assets and routes with prefix awareness; frontend resolves paths via `webPath()` and meta

## Test plan
- [ ] Open Sonarr instance modal, select text in URI, drag-release on Close and nav tabs — modal/tab should not change unintentionally
- [ ] On Config with unsaved edits, press `2` or click Processes — confirm prompt appears
- [ ] Max Seeding Time: pick weeks, clear input, blur — unit stays weeks; type into disabled field without select-all hack
- [ ] Enable Sonarr + Lidarr; configure Sonarr only; **Save** on Sonarr card succeeds while Lidarr remains incomplete
- [ ] Rename instance A, save instance B — rename for A remains pending until A is saved
- [ ] Set `UrlBase = "/qbitrr"` behind reverse proxy; verify UI loads, API calls, and static assets resolve correctly
- [ ] `npm run lint`, `tsc -b`, and pre-commit pass

Fixes #422


Made with [Cursor](https://cursor.com)