### PR TITLE
fix: recover when qBit instance init failed at startup

### DIFF
--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -936,7 +936,18 @@ class Arr:
         qbit_manager = self.manager.qbit_manager
         instances = qbit_manager.get_all_instances()
         if not instances:
-            return False
+            # No instances registered means initialisation failed at startup -- for
+            # example when qBitrr and qBittorrent are restarted together and the
+            # WebUI is not accepting connections yet. `_initialize_qbit_instances()`
+            # only ever runs from `_complete_startup()`, and nothing else populates
+            # `clients`, so without this retry the worker keeps reporting "Could not
+            # connect to qBit client" for the entire lifetime of the process even
+            # after qBittorrent becomes reachable again. Retry here so the loop can
+            # recover on its own; the caller already backs off 5 minutes on failure.
+            qbit_manager._initialize_qbit_instances()
+            instances = qbit_manager.get_all_instances()
+            if not instances:
+                return False
         return any(self._is_qbit_instance_reachable(name) for name in instances)
 
     def _retry_profile_switch_update(self, update_fn: Callable, kind: str) -> bool:


### PR DESCRIPTION
When `_init_instance()` fails during startup, `self.clients` stays empty for the entire lifetime of the process, and every torrent worker then loops on "Could not connect to qBit client" forever — even after qBittorrent becomes reachable again.

### Why it never recovers

`_initialize_qbit_instances()` is called from exactly one place (`_complete_startup()`), and `self.clients` is only ever populated from `_init_instance()` inside it. Nothing else writes to `clients`, and there is no `pop`/`clear`. So `_is_any_qbit_instance_reachable()` returns `False` on the `if not instances:` guard without ever probing:

```python
instances = qbit_manager.get_all_instances()
if not instances:
    return False
```

### Observed (5.12.11)

A container update restarted qBittorrent and qBitrr within one second of each other. qBitrr's init hit `Connection refused` (WebUI not listening yet), and all six torrent workers then reported the error every 5 minutes **for 36 hours**, while qBittorrent was healthy and reachable from inside the qBitrr container the whole time. Restarting qBitrr fixed it instantly.

### Fix

Retry the initialisation when no instances are registered, so the loop recovers on its own.

- clients empty + qBit reachable → recovers after 1 init attempt
- clients empty + qBit genuinely down → still `False`, unchanged behaviour
- clients already registered → nothing extra runs, no added load

The caller already backs off 5 minutes on failure, so the retry rate is bounded.