### PR TITLE
fix: use TMDB id for Overseerr TV lookups

### DIFF
--- a/qBitrr/arss.py
+++ b/qBitrr/arss.py
@@ -1591,7 +1591,9 @@ class Arr:
                     if type__ == "movie":
                         id__ = entry.get("media", {}).get("tmdbId")
                     elif type__ == "tv":
-                        id__ = entry.get("media", {}).get("tvdbId")
+                        # Overseerr's /api/v1/tv/{id} takes a TMDB id, not a TVDB id
+                        # (same as /api/v1/movie/{id}); `media` carries both.
+                        id__ = entry.get("media", {}).get("tmdbId")
                     else:
                         id__ = None
                     if not id__ or type_ != type__:


### PR DESCRIPTION
Overseerr's `/api/v1/tv/{id}` takes a **TMDB** id, exactly like `/api/v1/movie/{id}` — but the release-date lookup passes the **TVDB** id for TV entries. The request payload carries both `media.tmdbId` and `media.tvdbId`, so the wrong one is picked:

```python
if type__ == "movie":
    id__ = entry.get("media", {}).get("tmdbId")   # correct
elif type__ == "tv":
    id__ = entry.get("media", {}).get("tvdbId")   # -> /api/v1/tv/{tvdbId}
```

### Two failure modes, both observed live

**1. Visible.** The TVDB id does not exist in TMDB → TMDB 404 → Overseerr 500 → a `Failed to query release date from Overseerr` warning every loop:

```
[TMDB] Failed to fetch TV show details: Request failed with status code 404  tvId=367118
```

**2. Silent, and worse.** The TVDB id happens to be a valid TMDB id of a *different* show → HTTP 200 and a wrong `firstAirDate`, with nothing in the log:

| show | tvdbId | `/api/v1/tv/{tvdbId}` returns |
|---|---|---|
| Black Mirror | 253463 | 龙凤天骄 (unrelated series) |
| Rick and Morty | 275274 | 男管家 (unrelated series) |

That date feeds `if date > _now: continue`, so a wrong future date makes qBitrr skip searching for that media entirely — silently.

Of 14 monitored series checked: 12 returned a visible 500, 2 silently returned the wrong show.

### After the fix

The same failing lookups resolve correctly:

| tvdbId (before) | tmdbId (after) | result |
|---|---|---|
| 367118 → 500 | 90228 | Dune: Prophecy (2024-11-17) |
| 376098 → 500 | 95350 | Lanterns (2026-08-16) |
| 433637 → 500 | 224377 | Harry Potter (2026-12-25) |