### PR TITLE
ci: checkout fork PR heads for unittest and package jobs

### DIFF
--- a/.github/workflows/pull_requests.yml
+++ b/.github/workflows/pull_requests.yml
@@ -21,6 +21,7 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.PAT || github.token }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -66,6 +67,7 @@ jobs:
       with:
         fetch-depth: 0
         token: ${{ secrets.PAT || github.token }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
         ref: ${{ github.event.pull_request.head.ref }}
     - name: Install Homebrew dependencies
       if: runner.os == 'macOS'


### PR DESCRIPTION
## Summary
- Add `repository: ${{ github.event.pull_request.head.repo.full_name }}` to unittest and package checkout steps in `pull_requests.yml` (docker job already had this).
- Fixes fork PRs failing at Checkout with "branch or tag could not be found" (seen on #502/#503).

## Test plan
- [ ] Open or re-run CI on a fork PR and confirm unittest/package checkout succeeds
- [ ] Confirm same-repo PRs still checkout correctly