### PR TITLE
fix: Lidarr LIVE search loop (#516) and duration save

### DIFF
--- a/qBitrr/arss/arr_base.py
+++ b/qBitrr/arss/arr_base.py
@@ -343,7 +343,8 @@ class ArrBase(TorrentBatch, TorrentInspect, TorrentDispatch, TorrentLimits):
         )
 
         self.ignore_torrents_younger_than = CONFIG.get_duration(
-            f"{name}.Torrent.IgnoreTorrentsYoungerThan", fallback=600
+            f"{name}.Torrent.IgnoreTorrentsYoungerThan",
+            fallback=get_ignore_torrents_younger_than_effective(),
         )
         self.maximum_eta = CONFIG.get_duration(f"{name}.Torrent.MaximumETA", fallback=86400)
         self.maximum_deletable_percentage = CONFIG.get(
@@ -1265,6 +1266,7 @@ class ArrBase(TorrentBatch, TorrentInspect, TorrentDispatch, TorrentLimits):
         self.search_command_limit = self._get_search_command_limit()
         self.rss_sync_timer = self._get_rss_sync_timer()
         self.refresh_downloads_timer = self._get_refresh_downloads_timer()
+        self._reconcile_periodic_timer_last_checked()
 
         # --- Arr connection LIVE (not preserve-db identity) ---
         self.re_search = CONFIG.get(f"{name}.ReSearch", fallback=False)
@@ -1408,11 +1410,31 @@ class ArrBase(TorrentBatch, TorrentInspect, TorrentDispatch, TorrentLimits):
         self.search_requests_every_x_seconds = CONFIG.get_duration(
             f"{name}.EntrySearch.SearchRequestsEvery", fallback=300
         )
+        # Re-apply type gates after LIVE re-reads so Lidarr (and future types) cannot
+        # lose SearchByYear / Ombi / Overseerr overrides when keys are missing or present.
+        self._apply_type_feature_gates()
         if self.ombi_search_requests or self.overseerr_requests:
             if getattr(self, "request_search_timer", None) is None:
                 self.request_search_timer = 0
         else:
             self.request_search_timer = None
+
+    def _reconcile_periodic_timer_last_checked(self) -> None:
+        """Keep RssSync/RefreshDownloads last-checked in sync with LIVE timer values.
+
+        Mirrors init: timer ``> 0`` enables the check (epoch if previously disabled);
+        timer ``<= 0`` clears last-checked so the periodic call does not fire every loop.
+        """
+        if self.rss_sync_timer > 0:
+            if getattr(self, "rss_sync_timer_last_checked", None) is None:
+                self.rss_sync_timer_last_checked = datetime(1970, 1, 1)
+        else:
+            self.rss_sync_timer_last_checked = None
+        if self.refresh_downloads_timer > 0:
+            if getattr(self, "refresh_downloads_timer_last_checked", None) is None:
+                self.refresh_downloads_timer_last_checked = datetime(1970, 1, 1)
+        else:
+            self.refresh_downloads_timer_last_checked = None
 
     def apply_config_refresh(self, preserve_db: bool = True) -> None:
         """Refresh in-memory Arr settings from CONFIG without deleting the search DB.
@@ -3394,15 +3416,23 @@ class ArrBase(TorrentBatch, TorrentInspect, TorrentDispatch, TorrentLimits):
                     years_index = 0
                     totcommands = -1
                     timer = datetime.now()
+                years: list[int] = []
+                years_count = 0
                 if self.search_by_year:
+                    years, years_count = self.get_year_search()
+                if self.search_by_year and years:
                     totcommands = -1
                     if years_index == 0:
-                        years, years_count = self.get_year_search()
                         try:
                             self.search_current_year = years[years_index]
                         except Exception:
-                            self.search_current_year = years[: years_index + 1]
+                            self.search_current_year = None
                     self.logger.debug("Current year %s", self.search_current_year)
+                elif self.search_by_year:
+                    self.search_current_year = None
+                    self.logger.debug(
+                        "SearchByYear enabled but no years available; skipping year filter"
+                    )
                 try:
                     _db_maybe_reset_entry_searched_state_fn(self)
                     self.refresh_download_queue()
@@ -3424,7 +3454,7 @@ class ArrBase(TorrentBatch, TorrentInspect, TorrentDispatch, TorrentLimits):
                     # Check for new Overseerr/Ombi requests and trigger searches
                     self.run_request_search()
                     try:
-                        if self.search_by_year:
+                        if self.search_by_year and years and self.search_current_year in years:
                             if years.index(self.search_current_year) != years_count - 1:
                                 years_index += 1
                                 self.search_current_year = years[years_index]
@@ -3506,7 +3536,7 @@ class ArrBase(TorrentBatch, TorrentInspect, TorrentDispatch, TorrentLimits):
                     except DelayLoopException:
                         raise
                     except ValueError:
-                        self.logger.info("Loop completed, restarting it.")
+                        self.logger.exception("Search loop ValueError; restarting loop.")
                         self.loop_completed = True
                     except qbittorrentapi.exceptions.APIConnectionError as e:
                         self.logger.warning(e)

--- a/qBitrr/arss/placeholder_arr.py
+++ b/qBitrr/arss/placeholder_arr.py
@@ -243,7 +243,7 @@ class PlaceHolderArr(ArrBase):
             self.files_to_cleanup.clear()
 
     def _sync_loop_settings_from_config(self) -> None:
-        """Refresh PlaceHolder age window and completed folder from live Settings."""
+        """Refresh PlaceHolder age window, completed folder, and qBit seeding from live config."""
         sync_config_from_disk()
         ignore_seconds = get_ignore_torrents_younger_than_effective()
         if ignore_seconds != self.ignore_torrents_younger_than:
@@ -258,6 +258,8 @@ class PlaceHolderArr(ArrBase):
             self.manager.completed_folders.discard(self.completed_folder)
             self.completed_folder = new_completed
             self.manager.completed_folders.add(self.completed_folder)
+        if self.category in self.manager.qbit_managed_categories:
+            self._apply_qbit_seeding_config()
 
     def process_torrents(self):
         try:

--- a/qBitrr/arss/torrent_limits.py
+++ b/qBitrr/arss/torrent_limits.py
@@ -20,7 +20,7 @@ from qBitrr.arss.arr_shared import (
     _TrackerDataUnavailable,
     with_retry,
 )
-from qBitrr.duration_config import _DURATION_PATTERN, parse_duration
+from qBitrr.duration_config import _DURATION_PATTERN, _MAX_DURATION_STRING_LEN, parse_duration
 
 
 class TorrentLimits:
@@ -42,7 +42,7 @@ class TorrentLimits:
                 return value
             try:
                 text = str(value).strip()
-                if not text:
+                if not text or len(text) > _MAX_DURATION_STRING_LEN:
                     return default
                 if _DURATION_PATTERN.match(text):
                     return parse_duration(text, unit="seconds", fallback=default)

--- a/qBitrr/arss/torrent_limits.py
+++ b/qBitrr/arss/torrent_limits.py
@@ -20,6 +20,7 @@ from qBitrr.arss.arr_shared import (
     _TrackerDataUnavailable,
     with_retry,
 )
+from qBitrr.duration_config import _DURATION_PATTERN, parse_duration
 
 
 class TorrentLimits:
@@ -43,6 +44,8 @@ class TorrentLimits:
                 text = str(value).strip()
                 if not text:
                     return default
+                if _DURATION_PATTERN.match(text):
+                    return parse_duration(text, unit="seconds", fallback=default)
                 return float(text) if "." in text else int(text)
             except (TypeError, ValueError):
                 return default

--- a/qBitrr/arss/torrent_policy.py
+++ b/qBitrr/arss/torrent_policy.py
@@ -178,6 +178,7 @@ class TorrentPolicyManager(ArrBase):
         respawning; tracker-sort ownership and process spawn still follow manager init.
         """
         sync_config_from_disk()
+        self._sync_tracker_sort_settings_from_config()
         free_space, free_space_folder = get_free_space_guard_settings()
         want_enabled = (
             free_space != "-1"
@@ -196,6 +197,16 @@ class TorrentPolicyManager(ArrBase):
             if client is not None:
                 with contextlib.suppress(Exception):
                     client.torrents_create_tags(["qBitrr-free_space_paused"])
+
+    def _sync_tracker_sort_settings_from_config(self) -> None:
+        """Refresh merged tracker index / dead-tracker flags from live CONFIG."""
+        self.monitored_trackers = ArrBase.merge_global_tracker_blocks()
+        bad_msgs = ArrBase.global_bad_tracker_messages_union()
+        self.seeding_mode_global_bad_tracker_msg = bad_msgs
+        self._install_tracker_index(
+            build_tracker_index(self.monitored_trackers, bad_tracker_messages=bad_msgs)
+        )
+        self.remove_dead_trackers = ArrBase.global_remove_dead_trackers_union()
 
     @property
     def is_alive(self) -> bool:

--- a/qBitrr/duration_config.py
+++ b/qBitrr/duration_config.py
@@ -30,7 +30,10 @@ SUFFIX_TO_MINUTES = {
     "M": 43200,  # 30 days
 }
 
-_DURATION_PATTERN = re.compile(r"^\s*(-?\d+)\s*([sSmMhHdDwWM]?)\s*$")
+# After strip(): digits + optional single-letter suffix only (no ambiguous \\s*).
+# Cap length before matching to bound regex work on adversarial inputs.
+_MAX_DURATION_STRING_LEN = 32
+_DURATION_PATTERN = re.compile(r"^(-?\d+)([sSmMhHdDwWM]?)$")
 
 
 def parse_duration(
@@ -63,7 +66,7 @@ def _parse_duration_core(
     if isinstance(value, float) and value.is_integer():
         return int(value)
     s = str(value).strip()
-    if not s:
+    if not s or len(s) > _MAX_DURATION_STRING_LEN:
         return fallback
     m = _DURATION_PATTERN.match(s)
     if not m:

--- a/qBitrr/qbit_seeding_config.py
+++ b/qBitrr/qbit_seeding_config.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import Any
 
 from qBitrr.config import CONFIG
+from qBitrr.duration_config import parse_duration
 
 _SEEDING_KEYS = (
     "DownloadRateLimitPerTorrent",
@@ -21,6 +22,17 @@ _HNR_KEYS: dict[str, Any] = {
     "HitAndRunPartialSeedRatio": 1.0,
     "TrackerUpdateBuffer": 0,
 }
+
+_DURATION_OVERRIDE_KEYS = frozenset({"MaxSeedingTime", "TrackerUpdateBuffer"})
+
+
+def _normalize_seeding_override(override: dict[str, Any]) -> dict[str, Any]:
+    """Copy a category override and parse duration keys to native seconds."""
+    normalized = dict(override)
+    for key in _DURATION_OVERRIDE_KEYS:
+        if key in normalized:
+            normalized[key] = parse_duration(normalized[key], unit="seconds", fallback=-1)
+    return normalized
 
 
 def load_qbit_seeding_config(
@@ -55,7 +67,7 @@ def load_qbit_seeding_config(
     category_overrides: dict[str, dict] = {}
     for cat_config in CONFIG.get(f"{section}.CategorySeeding.Categories", fallback=[]):
         if isinstance(cat_config, dict) and "Name" in cat_config:
-            category_overrides[cat_config["Name"]] = cat_config
+            category_overrides[cat_config["Name"]] = _normalize_seeding_override(cat_config)
 
     result: dict[str, Any] = {
         "default_seeding": default_seeding,

--- a/qBitrr/webui/config_validate.py
+++ b/qBitrr/webui/config_validate.py
@@ -6,7 +6,7 @@ import re
 from collections.abc import Mapping
 from typing import Any
 
-from qBitrr.duration_config import _DURATION_PATTERN, parse_duration
+from qBitrr.duration_config import _DURATION_PATTERN, _MAX_DURATION_STRING_LEN, parse_duration
 from qBitrr.gen_config.fields import QBIT_FIELDS, SETTINGS_FIELDS, WEBUI_FIELDS, ConfigField
 from qBitrr.gen_config.fields_arr import ARR_FIELDS
 
@@ -80,6 +80,8 @@ def _as_duration(value: Any, *, unit: str) -> float | None:
         return float(value)
     if isinstance(value, str) and value.strip():
         s = value.strip()
+        if len(s) > _MAX_DURATION_STRING_LEN:
+            return None
         if _DURATION_PATTERN.match(s):
             return float(parse_duration(s, unit=unit, fallback=0))
         try:

--- a/qBitrr/webui/config_validate.py
+++ b/qBitrr/webui/config_validate.py
@@ -6,6 +6,7 @@ import re
 from collections.abc import Mapping
 from typing import Any
 
+from qBitrr.duration_config import _DURATION_PATTERN, parse_duration
 from qBitrr.gen_config.fields import QBIT_FIELDS, SETTINGS_FIELDS, WEBUI_FIELDS, ConfigField
 from qBitrr.gen_config.fields_arr import ARR_FIELDS
 
@@ -68,6 +69,26 @@ def _is_change_me(value: Any) -> bool:
     return isinstance(value, str) and value.strip().upper() == _CHANGE_ME
 
 
+def _as_duration(value: Any, *, unit: str) -> float | None:
+    """Parse a duration config value (number or suffixed string) into native units.
+
+    Returns None when ``value`` is not a valid duration expression.
+    """
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str) and value.strip():
+        s = value.strip()
+        if _DURATION_PATTERN.match(s):
+            return float(parse_duration(s, unit=unit, fallback=0))
+        try:
+            return float(s)
+        except ValueError:
+            return None
+    return None
+
+
 def _check_bounds(field: ConfigField, num: float, label: str) -> str | None:
     """Enforce minimum/maximum and -1 sentinel floors."""
     if field.minimum is not None and num < field.minimum:
@@ -98,7 +119,8 @@ def _validate_value(field: ConfigField, value: Any) -> str | None:
         return f"{label} must be a string"
 
     if kind == "duration":
-        num = _as_number(value)
+        unit = field.native_unit or "seconds"
+        num = _as_duration(value, unit=unit)
         if num is None:
             if field.required:
                 return f"{label} is required"

--- a/tests/test_config_validate.py
+++ b/tests/test_config_validate.py
@@ -104,6 +104,34 @@ class TestValidateConfigUpdate(unittest.TestCase):
         )
         self.assertEqual(errors, [])
 
+    def test_accepts_suffixed_qbit_max_seeding_time(self) -> None:
+        cfg = _config_from_toml(
+            """
+            [qBit]
+            Disabled = false
+            Host = "localhost"
+            Port = 8080
+            """
+        )
+        for value in ("1w", "7d", "1h", "60m", 604800, -1):
+            with self.subTest(value=value):
+                errors = validate_config_update(
+                    cfg, {"qBit.CategorySeeding.MaxSeedingTime": value}
+                )
+                self.assertEqual(errors, [], msg=f"unexpected errors for {value!r}: {errors}")
+
+    def test_rejects_invalid_suffixed_duration(self) -> None:
+        cfg = _config_from_toml(
+            """
+            [qBit]
+            Disabled = false
+            Host = "localhost"
+            Port = 8080
+            """
+        )
+        errors = validate_config_update(cfg, {"qBit.CategorySeeding.MaxSeedingTime": "nope"})
+        self.assertTrue(any(e["path"] == "qBit.CategorySeeding.MaxSeedingTime" for e in errors))
+
     def test_accepts_negative_one_arr_seeding_rate_limits(self) -> None:
         cfg = _config_from_toml(
             """

--- a/tests/test_config_validate.py
+++ b/tests/test_config_validate.py
@@ -132,6 +132,25 @@ class TestValidateConfigUpdate(unittest.TestCase):
         errors = validate_config_update(cfg, {"qBit.CategorySeeding.MaxSeedingTime": "nope"})
         self.assertTrue(any(e["path"] == "qBit.CategorySeeding.MaxSeedingTime" for e in errors))
 
+    def test_rejects_middle_space_and_oversized_duration(self) -> None:
+        cfg = _config_from_toml(
+            """
+            [qBit]
+            Disabled = false
+            Host = "localhost"
+            Port = 8080
+            """
+        )
+        for value in ("60 m", "1" * 40):
+            with self.subTest(value=value):
+                errors = validate_config_update(
+                    cfg, {"qBit.CategorySeeding.MaxSeedingTime": value}
+                )
+                self.assertTrue(
+                    any(e["path"] == "qBit.CategorySeeding.MaxSeedingTime" for e in errors),
+                    msg=f"expected rejection for {value!r}: {errors}",
+                )
+
     def test_accepts_negative_one_arr_seeding_rate_limits(self) -> None:
         cfg = _config_from_toml(
             """

--- a/tests/test_live_reload_characterization.py
+++ b/tests/test_live_reload_characterization.py
@@ -520,6 +520,7 @@ class TestPlaceHolderLiveSync(unittest.TestCase):
             arr.completed_folder = old_root / "failed"
             arr.manager = MagicMock()
             arr.manager.completed_folders = {arr.completed_folder}
+            arr.manager.qbit_managed_categories = set()
 
             with (
                 patch("qBitrr.arss.placeholder_arr.sync_config_from_disk"),
@@ -539,6 +540,151 @@ class TestPlaceHolderLiveSync(unittest.TestCase):
             self.assertEqual(arr.completed_folder, new_root / "failed")
             self.assertEqual(arr.manager.completed_folders, {new_root / "failed"})
             self.assertEqual(expiring.call_count, 3)
+
+
+class TestLidarrTypeFeatureGatesLive(unittest.TestCase):
+    """Issue #516: LIVE reload must not undo Lidarr type feature gates."""
+
+    def test_live_sync_keeps_search_by_year_false_for_lidarr(self) -> None:
+        from qBitrr.arss.lidarr import LidarrArr
+
+        arr = _bare_arr_for_refresh()
+        arr.__class__ = LidarrArr
+        arr._name = "Lidarr-Music"
+        arr.search_by_year = False
+        arr.ombi_search_requests = False
+        arr.overseerr_requests = False
+        arr.ombi_uri = None
+        arr.ombi_api_key = None
+        arr.overseerr_uri = None
+        arr.overseerr_api_key = None
+        arr.rss_sync_timer_last_checked = None
+        arr.refresh_downloads_timer_last_checked = None
+
+        def lidarr_config_get(key: str, fallback=None):
+            # Missing SearchByYear / Ombi / Overseerr keys → fallbacks that would undo gates
+            values = {
+                "Lidarr-Music.ReSearch": False,
+                "Lidarr-Music.ArrErrorCodesToBlocklist": [],
+                "Lidarr-Music.Torrent.CaseSensitiveMatches": False,
+                "Lidarr-Music.Torrent.FolderExclusionRegex": None,
+                "Lidarr-Music.Torrent.FileNameExclusionRegex": None,
+                "Lidarr-Music.Torrent.FileExtensionAllowlist": None,
+                "Lidarr-Music.Torrent.AutoDelete": False,
+                "Lidarr-Music.Torrent.MaximumDeletablePercentage": 0.95,
+                "Lidarr-Music.Torrent.DoNotRemoveSlow": False,
+                "Lidarr-Music.Torrent.ReSearchStalled": False,
+                "Lidarr-Music.Torrent.SeedingMode.RemoveDeadTrackers": False,
+                "Lidarr-Music.Torrent.SeedingMode.DownloadRateLimitPerTorrent": -1,
+                "Lidarr-Music.Torrent.SeedingMode.UploadRateLimitPerTorrent": -1,
+                "Lidarr-Music.Torrent.SeedingMode.MaxUploadRatio": -1,
+                "Lidarr-Music.Torrent.SeedingMode.RemoveTorrent": -1,
+                "Lidarr-Music.Torrent.SeedingMode.RemoveTrackerWithMessage": [],
+                "Lidarr-Music.Torrent.Trackers": [],
+                "qBit.Trackers": [],
+                "Lidarr-Music.EntrySearch.SearchAgainOnSearchCompletion": False,
+                "Lidarr-Music.EntrySearch.DoUpgradeSearch": False,
+                "Lidarr-Music.EntrySearch.QualityUnmetSearch": False,
+                "Lidarr-Music.EntrySearch.CustomFormatUnmetSearch": False,
+                "Lidarr-Music.EntrySearch.ForceMinimumCustomFormat": False,
+                "Lidarr-Music.EntrySearch.SearchMissing": True,
+                "Lidarr-Music.EntrySearch.AlsoSearchSpecials": False,
+                "Lidarr-Music.EntrySearch.Unmonitored": False,
+                "Lidarr-Music.EntrySearch.SearchInReverse": False,
+                "Lidarr-Music.EntrySearch.PrioritizeTodaysReleases": True,
+                "Lidarr-Music.EntrySearch.SearchBySeries": False,
+            }
+            return values.get(key, fallback)
+
+        with (
+            patch("qBitrr.arss.arr_base.CONFIG") as mock_config,
+            patch("qBitrr.arss.arr_base.PROCESS_ONLY", False),
+            patch("qBitrr.arss.arr_base.SEARCH_ONLY", True),
+            patch("qBitrr.arss.arr_base.sync_config_from_disk"),
+            patch.object(arr, "_get_ignore_torrents_younger_than", return_value=180),
+            patch.object(arr, "_get_maximum_eta", return_value=86400),
+            patch.object(arr, "_get_search_command_limit", return_value=5),
+            patch.object(arr, "_get_rss_sync_timer", return_value=15),
+            patch.object(arr, "_get_refresh_downloads_timer", return_value=1),
+            patch.object(arr, "_merge_trackers", return_value=[]),
+            patch.object(arr, "_install_tracker_index"),
+            patch("qBitrr.arss.arr_base.build_tracker_index", return_value=MagicMock()),
+        ):
+            mock_config.get.side_effect = lidarr_config_get
+            mock_config.get_duration.side_effect = lambda key, fallback=0, unit=None: fallback
+            arr._apply_arr_live_attrs_from_config()
+
+        self.assertFalse(arr.search_by_year)
+        self.assertFalse(arr.ombi_search_requests)
+        self.assertFalse(arr.overseerr_requests)
+        self.assertIsNone(arr.ombi_uri)
+        self.assertIsNone(arr.overseerr_uri)
+
+
+class TestPeriodicTimerLastCheckedLive(unittest.TestCase):
+    """LIVE timer changes must enable/disable *_last_checked like init."""
+
+    def test_enabling_rss_timer_sets_last_checked(self) -> None:
+        arr = _bare_arr_for_refresh()
+        arr.rss_sync_timer = 0
+        arr.rss_sync_timer_last_checked = None
+        arr.refresh_downloads_timer = 0
+        arr.refresh_downloads_timer_last_checked = None
+
+        with (
+            patch("qBitrr.arss.arr_base.CONFIG") as mock_config,
+            patch("qBitrr.arss.arr_base.PROCESS_ONLY", False),
+            patch("qBitrr.arss.arr_base.SEARCH_ONLY", True),
+            patch("qBitrr.arss.arr_base.sync_config_from_disk"),
+            patch.object(arr, "_get_ignore_torrents_younger_than", return_value=180),
+            patch.object(arr, "_get_maximum_eta", return_value=86400),
+            patch.object(arr, "_get_search_command_limit", return_value=5),
+            patch.object(arr, "_get_rss_sync_timer", return_value=15),
+            patch.object(arr, "_get_refresh_downloads_timer", return_value=1),
+            patch.object(arr, "_merge_trackers", return_value=[]),
+            patch.object(arr, "_install_tracker_index"),
+            patch("qBitrr.arss.arr_base.build_tracker_index", return_value=MagicMock()),
+        ):
+            mock_config.get.side_effect = _live_config_get
+            mock_config.get_duration.side_effect = lambda key, fallback=0, unit=None: fallback
+            arr._apply_arr_live_attrs_from_config()
+
+        self.assertEqual(arr.rss_sync_timer, 15)
+        self.assertIsNotNone(arr.rss_sync_timer_last_checked)
+        self.assertEqual(arr.refresh_downloads_timer, 1)
+        self.assertIsNotNone(arr.refresh_downloads_timer_last_checked)
+
+    def test_disabling_rss_timer_clears_last_checked(self) -> None:
+        from datetime import datetime
+
+        arr = _bare_arr_for_refresh()
+        arr.rss_sync_timer = 15
+        arr.rss_sync_timer_last_checked = datetime(1970, 1, 1)
+        arr.refresh_downloads_timer = 1
+        arr.refresh_downloads_timer_last_checked = datetime(1970, 1, 1)
+
+        with (
+            patch("qBitrr.arss.arr_base.CONFIG") as mock_config,
+            patch("qBitrr.arss.arr_base.PROCESS_ONLY", False),
+            patch("qBitrr.arss.arr_base.SEARCH_ONLY", True),
+            patch("qBitrr.arss.arr_base.sync_config_from_disk"),
+            patch.object(arr, "_get_ignore_torrents_younger_than", return_value=180),
+            patch.object(arr, "_get_maximum_eta", return_value=86400),
+            patch.object(arr, "_get_search_command_limit", return_value=5),
+            patch.object(arr, "_get_rss_sync_timer", return_value=0),
+            patch.object(arr, "_get_refresh_downloads_timer", return_value=0),
+            patch.object(arr, "_merge_trackers", return_value=[]),
+            patch.object(arr, "_install_tracker_index"),
+            patch("qBitrr.arss.arr_base.build_tracker_index", return_value=MagicMock()),
+        ):
+            mock_config.get.side_effect = _live_config_get
+            mock_config.get_duration.side_effect = lambda key, fallback=0, unit=None: fallback
+            arr._apply_arr_live_attrs_from_config()
+
+        self.assertEqual(arr.rss_sync_timer, 0)
+        self.assertIsNone(arr.rss_sync_timer_last_checked)
+        self.assertEqual(arr.refresh_downloads_timer, 0)
+        self.assertIsNone(arr.refresh_downloads_timer_last_checked)
 
 
 if __name__ == "__main__":

--- a/tests/test_phase1_helpers.py
+++ b/tests/test_phase1_helpers.py
@@ -68,11 +68,18 @@ class TestParseDurationGoldenMaster(unittest.TestCase):
         self.assertEqual(parse_duration("60", unit="seconds"), 60)
         self.assertEqual(parse_duration("2m", unit="seconds"), 120)
         self.assertEqual(parse_duration_to_seconds(None, fallback=99), 99)
+        self.assertEqual(parse_duration("1w", unit="seconds"), 604800)
+        self.assertEqual(parse_duration("-1", unit="seconds"), -1)
 
     def test_minutes_default_suffix_and_sub_one_rounding(self) -> None:
         self.assertEqual(parse_duration_to_minutes("5"), 5)
         self.assertEqual(parse_duration("30s", unit="minutes"), 1)
         self.assertEqual(parse_duration("2h", unit="minutes"), 120)
+
+    def test_rejects_middle_space_and_oversized_input(self) -> None:
+        self.assertEqual(parse_duration("60 m", unit="seconds", fallback=-7), -7)
+        self.assertEqual(parse_duration("1" * 40, unit="seconds", fallback=-7), -7)
+        self.assertEqual(parse_duration("0" + (" " * 40) + "x", unit="seconds", fallback=-7), -7)
 
 
 class TestNormalizeEnumGoldenMaster(unittest.TestCase):

--- a/webui/src/pages/config/configDocumentUtils.test.ts
+++ b/webui/src/pages/config/configDocumentUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   buildSectionDeleteChanges,
+  ensureArrDefaults,
   fieldErrorDataPath,
   findFieldErrorMessage,
   formatValidationErrors,
@@ -105,5 +106,23 @@ describe("buildSectionDeleteChanges", () => {
       qBit: null,
       "qBit-General": null,
     });
+  });
+});
+
+describe("ensureArrDefaults", () => {
+  it("omits SearchByYear and Ombi/Overseerr for Lidarr", () => {
+    const doc = ensureArrDefaults("Lidarr");
+    const entry = doc.EntrySearch as Record<string, unknown>;
+    expect(entry.SearchByYear).toBeUndefined();
+    expect(entry.Ombi).toBeUndefined();
+    expect(entry.Overseerr).toBeUndefined();
+  });
+
+  it("includes SearchByYear and Ombi/Overseerr for Radarr", () => {
+    const doc = ensureArrDefaults("Radarr");
+    const entry = doc.EntrySearch as Record<string, unknown>;
+    expect(entry.SearchByYear).toBe(true);
+    expect(entry.Ombi).toBeTruthy();
+    expect(entry.Overseerr).toBeTruthy();
   });
 });

--- a/webui/src/pages/config/configDocumentUtils.ts
+++ b/webui/src/pages/config/configDocumentUtils.ts
@@ -292,7 +292,6 @@ export function ensureArrDefaults(type: string): ConfigDocument {
     SearchMissing: true,
     Unmonitored: false,
     SearchLimit: 5,
-    SearchByYear: true,
     SearchInReverse: false,
     SearchRequestsEvery: 300,
     DoUpgradeSearch: false,
@@ -308,25 +307,31 @@ export function ensureArrDefaults(type: string): ConfigDocument {
     QualityProfileMappings: {},
   };
 
+  if (!isLidarr) {
+    entrySearch.SearchByYear = true;
+  }
+
   if (isSonarr) {
     entrySearch.AlsoSearchSpecials = false;
     entrySearch.SearchBySeries = "smart";
     entrySearch.PrioritizeTodaysReleases = true;
   }
 
-  entrySearch.Ombi = {
-    SearchOmbiRequests: false,
-    OmbiURI: "CHANGE_ME",
-    OmbiAPIKey: "CHANGE_ME",
-    ApprovedOnly: true,
-  };
-  entrySearch.Overseerr = {
-    SearchOverseerrRequests: false,
-    OverseerrURI: "CHANGE_ME",
-    OverseerrAPIKey: "CHANGE_ME",
-    ApprovedOnly: true,
-    Is4K: false,
-  };
+  if (!isLidarr) {
+    entrySearch.Ombi = {
+      SearchOmbiRequests: false,
+      OmbiURI: "CHANGE_ME",
+      OmbiAPIKey: "CHANGE_ME",
+      ApprovedOnly: true,
+    };
+    entrySearch.Overseerr = {
+      SearchOverseerrRequests: false,
+      OverseerrURI: "CHANGE_ME",
+      OverseerrAPIKey: "CHANGE_ME",
+      ApprovedOnly: true,
+      Is4K: false,
+    };
+  }
 
   const torrent: Record<string, unknown> = {
     CaseSensitiveMatches: false,


### PR DESCRIPTION
## Summary
- Fix [#516](https://github.com/Feramance/qBitrr/issues/516): re-apply Lidarr type feature gates after LIVE config sync so `SearchByYear` cannot flip back to `true` and kill the search loop; harden empty year-search handling and log `ValueError` with traceback.
- Close related LIVE gaps: IgnoreTorrentsYoungerThan init fallback, Rss/Refresh `*_last_checked` reconciliation, PlaceHolderArr qBit seeding refresh, TorrentPolicyManager tracker index refresh; omit gated keys from Lidarr WebUI defaults.
- Accept WebUI duration suffixes (`"1w"`, `"1h"`, …) in config save validation so MaxSeedingTime and other time fields persist; normalize override/tracker duration parsing end-to-end.

## Test plan
- [x] `python -m unittest tests.test_live_reload_characterization tests.test_config_validate`
- [x] Vitest `configDocumentUtils.test.ts` (Lidarr defaults)
- [ ] Manual: Lidarr with missing albums searches without “Loop completed, restarting it.” spam
- [ ] Manual: WebUI save qBit Max Seeding Time as weeks (`1w`) persists and applies

Fixes #516