### PR TITLE
fix: make classifier label provisioning race-safe

### DIFF
--- a/.github/scripts/classify_work_item.py
+++ b/.github/scripts/classify_work_item.py
@@ -417,6 +417,15 @@ def determine_flags(
     return sorted(flags)
 
 
+class GitHubAPIError(RuntimeError):
+    """GitHub REST failure with a machine-readable status and response body."""
+
+    def __init__(self, method: str, url: str, status: int, detail: str) -> None:
+        super().__init__(f"GitHub API {method} {url} failed: {status} {detail}")
+        self.status = status
+        self.detail = detail
+
+
 class GitHubAPI:
     """Small authenticated GitHub REST client with pagination."""
 
@@ -441,9 +450,7 @@ class GitHubAPI:
                 return json.loads(raw) if raw else None
         except urllib.error.HTTPError as error:
             detail = error.read().decode("utf-8", errors="replace")
-            raise RuntimeError(
-                f"GitHub API {method} {url} failed: {error.code} {detail}"
-            ) from error
+            raise GitHubAPIError(method, url, error.code, detail) from error
 
     def pages(self, path: str) -> list[Any]:
         """Read all pages from a list endpoint."""
@@ -524,7 +531,14 @@ def ensure_labels(api: GitHubAPI) -> None:
         if name in existing:
             api.request("PATCH", f"/labels/{urllib.parse.quote(name, safe='')}", payload)
         else:
-            api.request("POST", "/labels", payload)
+            try:
+                api.request("POST", "/labels", payload)
+            except GitHubAPIError as error:
+                # Concurrent runs can all observe a missing label. If another
+                # run wins creation, converge by updating the created label.
+                if error.status != 422 or '"already_exists"' not in error.detail:
+                    raise
+                api.request("PATCH", f"/labels/{urllib.parse.quote(name, safe='')}", payload)
 
 
 def update_classification_labels(

--- a/.github/scripts/tests/test_classify_work_item.py
+++ b/.github/scripts/tests/test_classify_work_item.py
@@ -53,6 +53,45 @@ class DigestTests(unittest.TestCase):
         )
 
 
+class LabelProvisioningTests(unittest.TestCase):
+    def test_concurrent_create_converges_to_patch(self) -> None:
+        class RacingAPI:
+            def __init__(self) -> None:
+                self.calls = []
+                self.raced = False
+
+            def pages(self, _path: str) -> list:
+                return []
+
+            def request(self, method: str, path: str, payload=None):
+                self.calls.append((method, path, payload))
+                if method == "POST" and not self.raced:
+                    self.raced = True
+                    raise classifier.GitHubAPIError(
+                        method,
+                        "https://api.github.test/labels",
+                        422,
+                        '{"errors":[{"code":"already_exists"}]}',
+                    )
+                return None
+
+        api = RacingAPI()
+        classifier.ensure_labels(api)
+        self.assertEqual(api.calls[0][0], "POST")
+        self.assertEqual(api.calls[1][0], "PATCH")
+
+    def test_non_conflict_create_failure_is_not_hidden(self) -> None:
+        class FailingAPI:
+            def pages(self, _path: str) -> list:
+                return []
+
+            def request(self, method: str, _path: str, payload=None):
+                raise classifier.GitHubAPIError(method, "https://api.github.test", 403, "denied")
+
+        with self.assertRaises(classifier.GitHubAPIError):
+            classifier.ensure_labels(FailingAPI())
+
+
 class IssueTests(unittest.TestCase):
     def issue(self, title: str, body: str, labels: list[str]) -> dict:
         return {"number": 1, "title": title, "body": body, "labels": [{"name": x} for x in labels]}


### PR DESCRIPTION
Handles concurrent classifier backfills that race while creating canonical labels. A 422 already_exists response now converges through PATCH; other API failures remain fatal. Adds regression coverage for both paths.