### PR TITLE
fix: ignore upstream issue references in PR text

### DIFF
--- a/.github/scripts/classify_work_item.py
+++ b/.github/scripts/classify_work_item.py
@@ -497,14 +497,29 @@ def authorized_override(
 
 def linked_issue_numbers(title: str, body: str, current_number: int) -> list[int]:
     """Extract same-repository issue references from PR text."""
-    matches = {int(value) for value in re.findall(r"(?<![\w/])#(\d+)\b", f"{title}\n{body}")}
+    text = f"{title}\n{body}"
+    matches: set[int] = set()
+    keywords = re.compile(
+        r"(?i)\b(?:close[sd]?|fix(?:es|ed)?|resolve[sd]?|refs?|references?|related\s+to|issue)\s*:?\s*"
+    )
+    for keyword in keywords.finditer(text):
+        line_end = text.find("\n", keyword.end())
+        segment = text[keyword.end() : line_end if line_end >= 0 else len(text)]
+        matches.update(int(value) for value in re.findall(r"(?<![\w/])#(\d+)\b", segment))
     matches.discard(current_number)
     return sorted(matches)
 
 
 def current_issue_classification(api: GitHubAPI, number: int) -> dict[str, Any] | None:
     """Return a linked issue's current type-label classification."""
-    issue = api.request("GET", f"/issues/{number}")
+    try:
+        issue = api.request("GET", f"/issues/{number}")
+    except GitHubAPIError as error:
+        # Release notes copied into dependency PRs can reference upstream issue
+        # numbers. A missing local issue is not a classifier failure.
+        if error.status == 404:
+            return None
+        raise
     categories = [
         LABEL_CATEGORY[label] for label in labels_from_item(issue) if label in LABEL_CATEGORY
     ]

--- a/.github/scripts/tests/test_classify_work_item.py
+++ b/.github/scripts/tests/test_classify_work_item.py
@@ -127,6 +127,23 @@ class IssueTests(unittest.TestCase):
         self.assertEqual(classifier.classify_issue(issue, "feature")[0], "feature")
 
 
+class LinkedIssueTests(unittest.TestCase):
+    def test_bare_release_note_references_are_ignored(self) -> None:
+        body = "Release notes\n- upstream change (#10995)\n- see owner/project#1298"
+        self.assertEqual(classifier.linked_issue_numbers("bump package", body, 10), [])
+
+    def test_explicit_link_keywords_are_supported(self) -> None:
+        body = "Fixes #12 and #13\nRelated to: #14\nRefs #10"
+        self.assertEqual(classifier.linked_issue_numbers("change", body, 10), [12, 13, 14])
+
+    def test_missing_local_issue_is_not_fatal(self) -> None:
+        class MissingAPI:
+            def request(self, method: str, path: str):
+                raise classifier.GitHubAPIError(method, path, 404, "not found")
+
+        self.assertIsNone(classifier.current_issue_classification(MissingAPI(), 999))
+
+
 class PullRequestTests(unittest.TestCase):
     def classify(self, value: dict, files: list[dict], labels=(), links=(), override=None) -> str:
         return classifier.classify_pr(value, files, labels, links, POLICY, override)[0]


### PR DESCRIPTION
Restricts linked-issue extraction to explicit linkage keywords and treats missing local issues as non-links. This prevents dependency changelogs from being mistaken for same-repository issues. Adds regression tests for bare references, explicit links, and 404 handling.