### PR TITLE
fix: exclude n8n status labels from classifier digests

### DIFF
--- a/.github/scripts/classify_work_item.py
+++ b/.github/scripts/classify_work_item.py
@@ -28,7 +28,7 @@ CLASSIFIER_VERSION = "github-classifier-v1"
 SCHEMA_VERSION = 1
 MARKER_PREFIX = "<!-- automation-classification:v1:"
 CHECK_NAME = "automation/classification"
-MANAGED_PREFIXES = ("automation/", "codex/")
+MANAGED_PREFIXES = ("automation/", "codex/", "n8n/")
 
 ISSUE_CATEGORIES = (
     "bug",

--- a/.github/scripts/tests/test_classify_work_item.py
+++ b/.github/scripts/tests/test_classify_work_item.py
@@ -48,7 +48,9 @@ class DigestTests(unittest.TestCase):
 
     def test_automation_labels_do_not_change_digest(self) -> None:
         self.assertEqual(
-            classifier.non_automation_labels(["bug", "automation/type:bug", "codex/bug"]),
+            classifier.non_automation_labels(
+                ["bug", "automation/type:bug", "codex/bug", "n8n/waiting-ci"]
+            ),
             ["bug"],
         )
 


### PR DESCRIPTION
Completes GitHub/n8n digest parity by treating n8n status labels as automation-owned metadata. Adds regression coverage; all 21 classifier tests pass locally.