### PR TITLE
ci: require Docker and CodeQL merge checks

### DIFF
--- a/.github/automation/merge-policy.json
+++ b/.github/automation/merge-policy.json
@@ -59,6 +59,14 @@
     {
       "app_slug": "github-actions",
       "pattern": "^package \\(.*\\)$"
+    },
+    {
+      "app_slug": "github-actions",
+      "pattern": "^Build Docker Images \\(.*\\)$"
+    },
+    {
+      "app_slug": "github-actions",
+      "pattern": "^Analyze \\(.*\\)$"
     }
   ],
   "schema_version": 1


### PR DESCRIPTION
Makes same-repository Docker builds and CodeQL analysis mandatory in the base-SHA merge policy. Fork-only publish jobs remain explicitly inapplicable. Classifier tests and JSON validation pass locally.