### PR TITLE
fix: classify PRs against the current base

### DIFF
--- a/.github/scripts/classify_work_item.py
+++ b/.github/scripts/classify_work_item.py
@@ -191,6 +191,7 @@ def pr_digest_input(
     labels: Sequence[str],
     linked_issues: Sequence[Mapping[str, Any]],
     classification_policy_digest: str,
+    base_sha: str,
 ) -> dict[str, Any]:
     """Build the canonical pull-request digest payload."""
     normalized_files = [
@@ -217,7 +218,7 @@ def pr_digest_input(
         },
         "base": {
             "ref": str((pull.get("base") or {}).get("ref") or ""),
-            "sha": str((pull.get("base") or {}).get("sha") or ""),
+            "sha": base_sha,
         },
         "head": {
             "ref": str((pull.get("head") or {}).get("ref") or ""),
@@ -700,6 +701,19 @@ def finish_check(api: GitHubAPI, check_id: int, conclusion: str, title: str, sum
     )
 
 
+def current_base_sha(api: GitHubAPI, pull: Mapping[str, Any]) -> str:
+    """Resolve the current tip of the pull request's target branch."""
+    base_ref = str((pull.get("base") or {}).get("ref") or "")
+    if not base_ref:
+        raise RuntimeError("pull request base ref is missing")
+    encoded_ref = urllib.parse.quote(base_ref, safe="")
+    response = api.request("GET", f"/git/ref/heads/{encoded_ref}")
+    base_sha = str((response.get("object") or {}).get("sha") or "").lower()
+    if not re.fullmatch(r"[0-9a-f]{40}", base_sha):
+        raise RuntimeError("current base ref did not resolve to a commit SHA")
+    return base_sha
+
+
 def classify_live_pr(api: GitHubAPI, number: int, policy: Mapping[str, Any]) -> None:
     """Fetch, classify, and persist one pull-request contract and head check."""
     pull = api.request("GET", f"/pulls/{number}")
@@ -718,7 +732,10 @@ def classify_live_pr(api: GitHubAPI, number: int, policy: Mapping[str, Any]) -> 
         override = authorized_override(api, number, labels, PR_CATEGORIES)
         category, evidence = classify_pr(pull, files, labels, links, policy, override)
         policy_hash = policy_digest(policy)
-        source = digest(pr_digest_input(api.repository, pull, files, labels, links, policy_hash))
+        base_sha = current_base_sha(api, pull)
+        source = digest(
+            pr_digest_input(api.repository, pull, files, labels, links, policy_hash, base_sha)
+        )
         flags = determine_flags(
             pull, files, policy, f"{pull.get('title') or ''}\n{pull.get('body') or ''}"
         )
@@ -728,7 +745,7 @@ def classify_live_pr(api: GitHubAPI, number: int, policy: Mapping[str, Any]) -> 
             flags,
             source,
             policy_hash,
-            str((pull.get("base") or {}).get("sha") or ""),
+            base_sha,
             head_sha,
             evidence,
         )

--- a/.github/scripts/tests/test_classify_work_item.py
+++ b/.github/scripts/tests/test_classify_work_item.py
@@ -54,6 +54,20 @@ class DigestTests(unittest.TestCase):
             ["bug"],
         )
 
+    def test_current_base_sha_encodes_branch_ref(self) -> None:
+        class RecordingAPI:
+            def __init__(self) -> None:
+                self.calls = []
+
+            def request(self, method: str, path: str, payload=None):
+                self.calls.append((method, path, payload))
+                return {"object": {"sha": "c" * 40}}
+
+        api = RecordingAPI()
+        value = classifier.current_base_sha(api, {"base": {"ref": "release/v1"}})
+        self.assertEqual(value, "c" * 40)
+        self.assertEqual(api.calls, [("GET", "/git/ref/heads/release%2Fv1", None)])
+
 
 class LabelProvisioningTests(unittest.TestCase):
     def test_classification_labels_replace_stale_managed_labels(self) -> None:

--- a/.github/workflows/classify-prs.yml
+++ b/.github/workflows/classify-prs.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Check out trusted base branch
       uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
       with:
-        ref: ${{ github.event.pull_request.base.sha || 'master' }}
+        ref: ${{ github.event.pull_request.base.ref || 'master' }}
         persist-credentials: false
     - name: Set up Python
       uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97


### PR DESCRIPTION
## Summary

- resolve the current target-branch SHA through the GitHub API
- bind policy and classification digests to that current SHA
- check out the trusted current base branch for pull_request_target classification
- cover encoded branch names with a deterministic unit test

## Validation

- classifier unit tests: 22 passed
- git diff --check: clean

This prevents older pull requests from referencing policy files at a historical base commit.