### PR TITLE
fix: use PAT for changelog release push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,6 +404,7 @@ jobs:
       with:
         fetch-depth: 0
         ref: master
+        token: ${{ secrets.PAT }}
     - name: Set up Python
       uses: actions/setup-python@v7
       with:


### PR DESCRIPTION
## Summary

Fix release workflow failure from Actions run `34091548410`.

The `Generate changelog and release notes` job successfully generated and signed the changelog commit, but its push to `master` was rejected by branch protection because `automation/classification` was required.

The earlier version-bump job succeeds under the same branch rule because its `actions/checkout` step persists `secrets.PAT`, which is authorized to bypass that rule. The changelog checkout was using the default `GITHUB_TOKEN` instead.

## Fix

Use `secrets.PAT` for the changelog job checkout as well, so `git-auto-commit-action` inherits the same authenticated remote used by the successful version-bump path.

## Validation

- Branch is based on current `master`.
- Diff is exactly one added line in `.github/workflows/release.yml`.
- No release-generation or changelog logic was otherwise changed.